### PR TITLE
a few org-capture related functions I forgot to move to spacehammer.el

### DIFF
--- a/spacehammer.el
+++ b/spacehammer.el
@@ -113,9 +113,6 @@ PID is a pid of the app (the caller is responsible to set that right)
 TITLE is a title of the window (the caller is responsible to set that right)
 KEYS is a string associated with a template (will be passed to `org-capture')"
   (setq systemwide-capture-previous-app-pid pid)
-  (message "activating capture frame" )
-  (message pid)
-  (message keys)
   (select-frame-by-name "capture")
   (set-frame-position nil 400 400)
   (set-frame-size nil 1000 400 t)
@@ -127,6 +124,25 @@ KEYS is a string associated with a template (will be passed to `org-capture')"
   "Delete the extra window if we're in a capture frame."
   (if (equal "capture" (frame-parameter nil 'name))
       (delete-other-windows)))
+
+(defadvice org-capture-finalize
+    (after delete-capture-frame activate)
+  "Advise capture-finalize to close the frame."
+  (when (and (equal "capture" (frame-parameter nil 'name))
+             (not (eq this-command 'org-capture-refile)))
+    (spacehammer/switch-to-app systemwide-capture-previous-app-pid)
+    (delete-frame)))
+
+(defadvice org-capture-refile
+    (after delete-capture-frame activate)
+  "Advise ‘org-refile’ to close the frame."
+  (delete-frame))
+
+(defadvice user-error
+    (before before-user-error activate)
+  "Advice"
+  (when (eq (buffer-name) "*Org Select*")
+    (spacehammer/switch-to-app systemwide-capture-previous-app-pid)))
 
 (provide 'spacehammer)
 


### PR DESCRIPTION
My memory fails to recall if there's any historical significance of these functions, but I assume they are required for "Org-capture From Anywhere" feature to work properly. Somehow I forgot to move them into spacehammer.el and they remained in my own config.