### PR TITLE
Remove commas for fennel 0.3.0

### DIFF
--- a/lib/apps.fnl
+++ b/lib/apps.fnl
@@ -21,7 +21,7 @@
 (local lifecycle (require :lib.lifecycle))
 
 
-(local log (hs.logger.new "apps.fnl", "debug"))
+(local log (hs.logger.new "apps.fnl" "debug"))
 
 (local actions (atom.new nil))
 (var fsm nil)

--- a/lib/atom.fnl
+++ b/lib/atom.fnl
@@ -38,10 +38,15 @@
     (notify-watchers atom next-value prev-value)
     atom))
 
-{:atom atom
- :new atom
- :deref deref
+(fn reset!
+  [atom v]
+  (swap! atom (fn [] v)))
+
+{:atom            atom
+ :new             atom
+ :deref           deref
  :notify-watchers notify-watchers
- :add-watch add-watch
- :remove-watch remove-watch
- :swap! swap!}
+ :add-watch       add-watch
+ :remove-watch    remove-watch
+ :reset!          reset!
+ :swap!           swap!}

--- a/lib/functional.fnl
+++ b/lib/functional.fnl
@@ -26,7 +26,7 @@
 
 (fn has-some?
   [list]
-  (and list (> (# list) 0)))
+  (and list (> (length list) 0)))
 
 (fn identity
   [x] x)
@@ -37,7 +37,7 @@
 
 (fn last
   [list]
-  (. list (# list)))
+  (. list (length list)))
 
 (fn logf
   [...]
@@ -49,19 +49,25 @@
   []
   nil)
 
+(fn slice-end-idx
+  [end-pos list]
+  (if (< end-pos 0)
+    (+ (length list) end-pos)
+    end-pos))
+
 (fn slice-start-end
   [start end list]
-  (let [end (if (< end 0)
-                (+ (# list) end)
-                end)]
+  (let [end+ (if (< end 0)
+              (+ (length list) end)
+              end)]
     (var sliced [])
-    (for [i start end]
+    (for [i start end+]
       (table.insert sliced (. list i)))
     sliced))
 
 (fn slice-start
   [start list]
-  (slice-start-end start (# list) list))
+  (slice-start-end start (length list) list))
 
 (fn slice
   [start end list]
@@ -69,6 +75,7 @@
            (not list))
       (slice-start start end)
       (slice-start-end start end list)))
+
 
 (fn split
   [search str]
@@ -161,7 +168,7 @@
 (fn some
   [f tbl]
   (let [filtered (filter f tbl)]
-    (>= (# filtered) 1)))
+    (>= (length filtered) 1)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -171,7 +178,7 @@
 (fn eq?
   [l1 l2]
   (if (and (= (type l1) (type l2) "table")
-           (= (# l1) (# l2)))
+           (= (length l1) (length l2)))
       (fu.every l1
                 (fn [v] (contains? v l2)))
       (= (type l1) (type l2))

--- a/lib/macros.fnl
+++ b/lib/macros.fnl
@@ -1,8 +1,8 @@
 (fn when-let
   [[var-name value] body1 ...]
   (assert body1 "expected body")
-  `(let [@var-name @value]
-     (when @var-name
-       @body1 @...)))
+  `(let [,var-name ,value]
+     (when ,var-name
+       ,body1 ,...)))
 
 {:when-let when-let}

--- a/lib/modal.fnl
+++ b/lib/modal.fnl
@@ -279,7 +279,7 @@
   (let [{:config config
          :history history} state
         history (slice 1 -1 history)
-        main-menu (= 0 (# history))
+        main-menu (= 0 (length history))
         navigate (if main-menu
                      idle->active
                      active->submenu)]

--- a/lib/text.fnl
+++ b/lib/text.fnl
@@ -9,7 +9,7 @@
 (fn max-length
   [items]
   (reduce
-   (fn [max [key _]]  (math.max max (# key)))
+   (fn [max [key _]]  (math.max max (length key)))
    0
    items))
 

--- a/windows.fnl
+++ b/windows.fnl
@@ -17,7 +17,7 @@
       (when (= (type tbl) :nil)
         (tset self id []))
       (when tbl
-        (let [last-el (. tbl (# tbl))]
+        (let [last-el (. tbl (length tbl))]
           (when (~= last-el (: win :frame))
             (table.insert tbl (: win :frame))))))))
 
@@ -28,7 +28,7 @@
         tbl (. self id)]
     (when (and win tbl)
       (let [el (table.remove tbl)
-            num-of-undos (# tbl)]
+            num-of-undos (length tbl)]
         (if el
             (do
               (: win :setFrame el)


### PR DESCRIPTION
- Removed `,` comma from lib/apps.fnl
- Replaced `@` with `,` comma
- Replace `(# list)` with `(length list)`
- Updated end index calculation in `lib/functional.fnl:slice-start-end` due to unexpected `if` inside a `let`.

Seems to be working for me in 0.3.0 but please confirm :smile: