### PR TITLE
Fix local app bindings \ menus

### DIFF
--- a/core.fnl
+++ b/core.fnl
@@ -5,6 +5,8 @@
 (local {:contains? contains?
         :for-each  for-each
         :map       map
+        :merge     merge
+        :reduce    reduce
         :split     split
         :some      some} (require :lib.functional))
 (require-macros :lib.macros)
@@ -112,8 +114,11 @@
                 :lib.modal
                 :lib.apps])
 
-(->> modules
-     (map require)
-     (for-each
-      (fn [module]
-        (module.init config))))
+;; Create a global reference so services like hs.application.watcher
+;; do not get garbage collected.
+(global resources
+        (->> modules
+             (map (fn [path]
+                    (let [module (require path)]
+                      {path (module.init config)})))
+             (reduce #(merge $1 $2) {})))


### PR DESCRIPTION
Fixes agzam/spacehammer#31 where local key bindings and menu items randomly stopped working.

Research suggests the hs.application.watcher instance was garbage-collected
https://github.com/Hammerspoon/hammerspoon/issues/681

Fix creates a global var resources table to store the output of every module.init.