### PR TITLE
Fix chrome tab navigation

### DIFF
--- a/chrome.fnl
+++ b/chrome.fnl
@@ -5,7 +5,7 @@
   []
   "
   Activate the Chrome > File > Open Location... action which moves focus to the
-  address\search bar.
+  address\\search bar.
   Returns nil
   "
   (when-let [app (: (hs.window.focusedWindow) :application)]


### PR DESCRIPTION
- Escaped \ char used in docstring of chrome open location function