### PR TITLE
Add compose function to functional.fnl

### DIFF
--- a/lib/functional.fnl
+++ b/lib/functional.fnl
@@ -19,6 +19,17 @@
   (when (and f (= (type f) :function))
     (f)))
 
+(fn compose
+  [...]
+  (let [fs [...]
+        total (length fs)]
+    (fn [v]
+      (var res v)
+      (for [i 0 (- total 1)]
+        (let [f (. fs (- total i))]
+          (set res (f res))))
+      res)))
+
 (fn contains?
   [x xs]
   "Returns true if key is present in the given collection, otherwise returns false."
@@ -212,6 +223,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 {:call-when call-when
+ :compose   compose
  :concat    concat
  :contains? contains?
  :count     count


### PR DESCRIPTION
A simple compose implementation for functional.fnl.

Takes a list of functions and applies them in reverse order to an input. Very inline with Clojure's `comp` function.

Context in upcoming work:

It was helpful in an upcoming module to read selected text using https://www.hammerspoon.org/docs/hs.uielement.html#selectedText and sending it to a tmux buffer which allows even the most basic of editors to have a REPL experience.

That feature is working on my local but I need to think about how to architect it to make it easy to add support for sending text to other terminals and experiment with copying and reading from the clipboard to get better compatibility with the browser.