### PR TITLE
Allow closing modals by ctrl-[

### DIFF
--- a/lib/modal.fnl
+++ b/lib/modal.fnl
@@ -204,6 +204,9 @@ switching menus in one place which is then powered by config.fnl.
                          item.items)))
            (map bind-item))
       (concat [{:key :ESCAPE
+                :action deactivate-modal}
+               {:mods [:ctrl]
+                :key "["
                 :action deactivate-modal}])
       (bind-keys)))
 


### PR DESCRIPTION
This is provided by default in many places (vim, evil etc) so it makes sense to include it here too. It's the way I normally use for escape instead of reaching for the esc button.