### PR TITLE
feat: Edit-with-emacs detects text selection

### DIFF
--- a/CHANGELOG.ORG
+++ b/CHANGELOG.ORG
@@ -1,4 +1,6 @@
 * Note: sorted starting from the most recent changes
+  - [2020-05-14 Thu]
+    - Edit-with-emacs feature now detects if there's a pre-selected text already and edits only that chunk
   - [2020-05-13 Wed]
     - Addressed workaround for regression in fennel 0.4.0 https://github.com/bakpakin/Fennel/issues/276
   - [2020-02-23 Sun]

--- a/config.fnl
+++ b/config.fnl
@@ -70,15 +70,14 @@
 ;; [x] |-- f - fullscreen
 ;; [x] |-- v - split
 ;;
-;; [x] cmd-n - next-app
-;; [x] cmd-p - prev-app
+;; [x] alt-n - next-app
+;; [x] alt-p - prev-app
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Initialize
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(emacs.enable-edit-with-emacs)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Actions
@@ -357,8 +356,10 @@
          :action "apps:prev-app"}
         {:mods [:cmd :ctrl]
          :key "`"
-         :action toggle-console}])
-
+         :action toggle-console}
+        {:mods [:cmd :ctrl]
+         :key :o
+         :action "emacs:edit-with-emacs"}])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; App Specific Config
@@ -401,12 +402,8 @@
 
 (local emacs-config
        {:key "Emacs"
-        :activate (fn []
-                    (vim.disable)
-                    (emacs.disable-edit-with-emacs))
-        :deactivate (fn []
-                      (vim.enable)
-                      (emacs.enable-edit-with-emacs))
+        :activate (fn [] (vim.disable))
+        :deactivate (fn [] (vim.enable))
         :launch "emacs:maximize"
         :items []
         :keys []})

--- a/emacs.fnl
+++ b/emacs.fnl
@@ -37,10 +37,14 @@
                      " -e '(spacehammer/edit-with-emacs "
                      pid " " title " " screen " )' &")
         co          (coroutine.create (fn [run-str]
-                                        (io.popen run-str)))]
-    ;; select all + copy
-    (hs.eventtap.keyStroke [:cmd] :a)
-    (hs.eventtap.keyStroke [:cmd] :c)
+                                        (io.popen run-str)))
+        prev        (hs.pasteboard.changeCount)
+        _           (hs.eventtap.keyStroke [:cmd] :c)
+        next        (hs.pasteboard.changeCount)]
+    (when (= prev next)         ; Pasteboard was not updated so no text was selected
+      (hs.eventtap.keyStroke [:cmd] :a)  ; select all
+      (hs.eventtap.keyStroke [:cmd] :c)  ; copy
+      )
     (coroutine.resume co run-str)))
 
 (fn edit-with-emacs-callback [pid title screen]
@@ -53,9 +57,6 @@
     (when (and edit-window scr)
       (: edit-window :moveToScreen scr)
       (: windows :center-window-frame))))
-
-;; global keybinging to invoke edit-with-emacs feature
-(local edit-with-emacs-key (hs.hotkey.new [:cmd :ctrl] :o nil edit-with-emacs))
 
 (fn run-emacs-fn
   [elisp-fn args]
@@ -117,11 +118,6 @@
       (: app :activate)
       (: app :selectMenuItem [:Edit :Paste]))))
 
-(fn disable-edit-with-emacs []
-  (: edit-with-emacs-key :disable))
-
-(fn enable-edit-with-emacs []
-  (: edit-with-emacs-key :enable))
 
 (fn maximize
   []
@@ -137,10 +133,8 @@
          (windows.maximize-window-frame))))))
 
 {:capture                          capture
- :disable-edit-with-emacs          disable-edit-with-emacs
  :edit-with-emacs                  edit-with-emacs
  :editWithEmacsCallback            edit-with-emacs-callback
- :enable-edit-with-emacs           enable-edit-with-emacs
  :full-screen                      full-screen
  :maximize                         maximize
  :note                             (fn [] (capture true))


### PR DESCRIPTION
addresses https://github.com/agzam/spacehammer/issues/55

Also removed enabling/disabling editing. That was done initially, (I think) because spawning multiple emacsclient sessions would block the thread. No longer is an issue.