### PR TITLE
Addresses regression in fennel 0.4.0 in -?>> macro

### DIFF
--- a/CHANGELOG.ORG
+++ b/CHANGELOG.ORG
@@ -1,4 +1,6 @@
 * Note: sorted starting from the most recent changes
+  - [2020-05-13 Wed]
+    - Addressed workaround for regression in fennel 0.4.0 https://github.com/bakpakin/Fennel/issues/276
   - [2020-02-23 Sun]
     - Move to display feature. Windows modal: <LEAD w> now would display a big
       number at the corner of each display, when a number on the keypad is

--- a/lib/modal.fnl
+++ b/lib/modal.fnl
@@ -27,6 +27,7 @@ switching menus in one place which is then powered by config.fnl.
         :filter    filter
         :get       get
         :has-some? has-some?
+        :identity  identity
         :join      join
         :last      last
         :map       map
@@ -228,7 +229,8 @@ switching menus in one place which is then powered by config.fnl.
   "
   (let [mods (-?>> item.mods
                   (map (fn [m] (or (. mod-chars m) m)))
-                  (join " "))]
+                  (join " ")
+                  (identity))]
     (.. (or mods "")
         (if mods " + " "")
         item.key)))


### PR DESCRIPTION
- Error: last form in a -?>> macro does not receive all args
- Workaround is to add identity function as last form
- Reported upstream in https://github.com/bakpakin/Fennel/issues/276