### PR TITLE
Update comment to point to current private config location

### DIFF
--- a/config.fnl
+++ b/config.fnl
@@ -114,7 +114,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; If you would like to customize this we recommend copying this file to
-;; ~/.hammerspoon/private/config.fnl. That will be used in place of the default
+;; ~/.spacehammer/config.fnl. That will be used in place of the default
 ;; and will not be overwritten by upstream changes when spacehammer is updated.
 (local music-app "Spotify")
 


### PR DESCRIPTION
Just updating a comment in the default/example config to point to the current private config location as specified in the README.