### PR TITLE
Fixes agzam/spacehamer#68 support for Hammerspoon 0.9.79 and Lua 5.4

### DIFF
--- a/CHANGELOG.ORG
+++ b/CHANGELOG.ORG
@@ -1,4 +1,6 @@
 * Note: sorted starting from the most recent changes
+  - [2020-09-20 Sun]
+    - Fixed support for Hammerspoon 0.9.79 which uses Lua 5.4 see https://github.com/agzam/spacehammer/pull/70 for instructions
   - [2020-05-14 Thu]
     - Edit-with-emacs feature now detects if there's a pre-selected text already and edits only that chunk
   - [2020-05-13 Wed]

--- a/init.lua
+++ b/init.lua
@@ -13,6 +13,12 @@
 
 hs.alert.show("Spacehammer config loaded")
 
+-- Support upcoming 5.4 release and also use luarocks' local path
+package.path = package.path .. ";" .. os.getenv("HOME") .. "/.luarocks/share/lua/5.4/?.lua;" .. os.getenv("HOME") .. "/.luarocks/share/lua/5.4/?/init.lua"
+package.cpath = package.cpath .. ";" .. os.getenv("HOME") .. "/.luarocks/lib/lua/5.4/?.so"
+package.path = package.path .. ";" .. os.getenv("HOME") .. "/.luarocks/share/lua/5.3/?.lua;" .. os.getenv("HOME") .. "/.luarocks/share/lua/5.3/?/init.lua"
+package.cpath = package.cpath .. ";" .. os.getenv("HOME") .. "/.luarocks/lib/lua/5.3/?.so"
+
 fennel = require("fennel")
 table.insert(package.loaders or package.searchers, fennel.searcher)
 


### PR DESCRIPTION
# Fixes 
- Fixes agzam/spacehammer#68
- Adds support for luarocks with 5.4 which defaults to a local install path 
- Adds support for local luarocks 5.3 for compatability 

# To fix Spacehammer for Spacehammer 0.9.79 

## Upgrade Lua
1. Download Lua 5.4 from http://www.lua.org/download.html 
2. Extract and cd into lua-5.4.0 
3. Run `make` to build from source
4. Run `make install` to install in expected location on your system. May need to be prefixed with `sudo`.

## Upgrade Spacehammer
1. Enter the hammerspoon directory
   ```bash
   cd ~/.hammerspoon/
   ```
2. Update spacehammer
   ```bash
   git fetch git@github.com:agzam/spacehammer.git master
   ````

## Update luarocks and reinstall fennel
1. Point luarocks to 5.4
   ```bash
   luarocks config lua_version 5.4
   ```
2. Install fennel
   ```bash
   install fennel
   ```