### PR TITLE
fix moving to another screen

### DIFF
--- a/windows.fnl
+++ b/windows.fnl
@@ -331,8 +331,9 @@
 (fn move-to-screen
   [screen]
   "Moves current window onto given hs.screen instance"
-  (let [w (hs.window.focusedWindow)]
-    (: w :moveToScreen screen)))
+  (let [w (hs.window.focusedWindow)
+        no-resize true]
+    (: w :moveToScreen screen no-resize)))
 
 (fn move-screen
   [method]


### PR DESCRIPTION
It looks like there's an issue with moving some windows across screens.
By default, Hammerspoon tries to resize the window (if it is, for example, is
being moved to a display with a smaller resolution).
That, in some cases, forces the window to get resized but not moving onto
another screen (it would keep changing its size but stubbornly stay on the same screen)

Notably, browser windows wouldn't move. I find that it works better if it
doesn't even attempt to resize and would simply move the window.