### PR TITLE
Add basic REPL support.

### DIFF
--- a/core.fnl
+++ b/core.fnl
@@ -21,7 +21,6 @@
         :reduce    reduce
         :split     split
         :some      some} (require :lib.functional))
-(local repl (require :repl))
 (require-macros :lib.macros)
 
 ;; Make ~/.spacehammer folder override repo files
@@ -212,5 +211,3 @@ Returns nil. This function causes side-effects.
                     (let [module (require path)]
                       {path (module.init config)})))
              (reduce #(merge $1 $2) {})))
-
-(repl.start)

--- a/core.fnl
+++ b/core.fnl
@@ -21,6 +21,7 @@
         :reduce    reduce
         :split     split
         :some      some} (require :lib.functional))
+(local repl (require :repl))
 (require-macros :lib.macros)
 
 ;; Make ~/.spacehammer folder override repo files
@@ -211,3 +212,5 @@ Returns nil. This function causes side-effects.
                     (let [module (require path)]
                       {path (module.init config)})))
              (reduce #(merge $1 $2) {})))
+
+(repl.start)

--- a/repl.fnl
+++ b/repl.fnl
@@ -13,16 +13,13 @@
                                   (: :read "*all")
                                   (: :gsub "^#![^\n]*\n" "")))
                   (: f :close))
-    "eval" (do
-             (tset msg
-                   :pp view
-                   :code (fennel.compileString msg.code)))
     (f msg)))
 
 
 (fn start
   []
-  (set server (jeejah.start nil {:middleware fennel-middleware
+  (set server (jeejah.start nil {:fennel true
+                                 :middleware fennel-middleware
                                  :debug true}))
   (print (hs.inspect server))
   server)

--- a/repl.fnl
+++ b/repl.fnl
@@ -1,0 +1,36 @@
+(local fennel (require :fennel))
+(local jeejah (require :jeejah))
+(local view (require :fennelview))
+(var server nil)
+
+(fn fennel-middleware
+  [f msg]
+  (match msg.op
+    "load-file" (let [f (assert (io.open msg.filename "rb"))]
+                  (tset msg
+                        :op "eval"
+                        :code (-> f
+                                  (: :read "*all")
+                                  (: :gsub "^#![^\n]*\n" "")))
+                  (: f :close))
+    "eval" (do
+             (tset msg
+                   :pp view
+                   :code (fennel.compileString msg.code)))
+    (f msg)))
+
+
+(fn start
+  []
+  (set server (jeejah.start nil {:middleware fennel-middleware
+                                 :debug true}))
+  (print (hs.inspect server))
+  server)
+
+(fn stop
+  []
+  (jeejah.stop server)
+  (set server nil))
+
+{:start start
+ :stop stop}


### PR DESCRIPTION
This adds basic REPL support, built on @eccentric-j 's work.

If you set `:serialize toprint` (or any function that will convert an arbitrary object to a string) in the call to `start` then you can get around it needing serpent entirely, otherwise you need a version of `serpent` that works with Lua 5.4

Requires jeejah-0.3.2 (latest at the time of writing)

My config has this at the bottom, just before the exports section

```lisp
(local repl (require :repl))

(repl.run (repl.start)
```

To test it I bound some keys to start, stop, and check the status:

```lisp
(local repl (require :repl))

(local coroutine (require :coroutine))
(var replserver (repl.start))
(repl.run replserver)
(fn strt [] (set replserver (repl.start)))
(fn run [] (repl.run replserver))
(fn stp [] (repl.stop replserver))
(fn sts [] (alert (coroutine.status replserver)))
(hs.hotkey.bind ["ctrl" "shift"] "a" "start" strt nil nil)
(hs.hotkey.bind ["ctrl" "shift"] "r" "run" run nil nil)
(hs.hotkey.bind ["ctrl" "shift"] "s" "stop" stp nil nil)
(hs.hotkey.bind ["ctrl" "shift"] "t" "status" sts nil nil)
```