### PR TITLE
wip: Add advice functionality

### DIFF
--- a/lib/advice.fnl
+++ b/lib/advice.fnl
@@ -5,23 +5,19 @@
     `(global ,name (fn ,args ,docstring
                      (let [orig# (fn ,args ,...)]
                        ;; Call :before funcs with original args
-                       (if (. _G (.. ,(tostring name) "__before"))
-                         (let [bfunc# (. _G (.. ,(tostring name) "__before"))]
-                           (bfunc# (table.unpack ,args))))
+                       (when-let [bfunc# (. _G (.. ,(tostring name) "__before"))]
+                                 (bfunc# (table.unpack ,args)))
                        ;; If there is :override, then don't call the original
-                       (let [rv# (if (. _G (.. ,(tostring name) "__override"))
-                                   (let [ofunc# (. _G (.. ,(tostring name) "__override"))]
-                                     (ofunc# (table.unpack ,args)))
+                       (let [rv# (if-let [ofunc# (. _G (.. ,(tostring name) "__override"))]
+                                   (ofunc# (table.unpack ,args))
                                    ;; If there is ::around, call it instead,
                                    ;; providing the original
-                                   (if (. _G (.. ,(tostring name) "__around"))
-                                     (let [afunc# (. _G (.. ,(tostring name) "__around"))]
-                                       (afunc# orig# (table.unpack ,args)))
+                                   (if-let [afunc# (. _G (.. ,(tostring name) "__around"))]
+                                     (afunc# orig# (table.unpack ,args))
                                      (orig# (table.unpack ,args))))]
                          ;; Call :after funcs
-                         (if (. _G (.. ,(tostring name) "__after"))
-                           (let [afunc# (. _G (.. ,(tostring name) "__after"))]
-                             (afunc# (table.unpack ,args))))
+                         (when-let [afunc# (. _G (.. ,(tostring name) "__after"))]
+                                   (afunc# (table.unpack ,args)))
                          rv#))))))
 
 (fn defadvice!

--- a/lib/advice.fnl
+++ b/lib/advice.fnl
@@ -1,4 +1,4 @@
-(fn advisable-fn
+(fn afn
   [name args docstring ...]
   ;; TODO: Instrument the function body with calls to its advice
   (let [docstring (tostring docstring)]
@@ -29,5 +29,5 @@
      (add-advice!# ,funcname
                   ,where ,name))))
 
-{: advisable-fn
+{: afn
  : defadvice!}

--- a/lib/utils.fnl
+++ b/lib/utils.fnl
@@ -18,4 +18,19 @@
   (let [filter (hs.window.filter.new)]
     (: filter :setAppFilter :Emacs {:allowRoles [:AXUnknown :AXStandardWindow :AXDialog :AXSystemDialog]})))
 
-{:global-filter global-filter}
+(global add-advice!
+  (fn [name where advice]
+    (let [where-tag (.. "__" (tostring where))]
+    (print "Adding advice to " name) ; DELETEME
+      ;; TODO: Accept symbol
+      ;; TODO: Support more than one per 'where'?
+      (tset _G (.. name where-tag) advice))))
+
+(fn remove-advice!
+  [name where]
+  (let [where-tag (.. "__" (tostring where))]
+      (tset _G (.. name where-tag) nil)))
+
+{: add-advice!
+ : remove-advice!
+ :global-filter global-filter}

--- a/macros.fnl
+++ b/macros.fnl
@@ -1,0 +1,35 @@
+(fn advisable-fn
+  [name args docstring ...]
+  ;; TODO: Instrument the function body with calls to its advice
+  (let [docstring (tostring docstring)]
+    `(global ,name (fn ,args ,docstring
+                     ;; Call :before funcs with original args
+                     (if (. _G (.. ,(tostring name) "__before"))
+                       (let [bfunc# (. _G (.. ,(tostring name) "__before"))]
+                         (bfunc# (table.unpack ,args))))
+                     ;; TODO: Call :before-while funcs, shortcircuiting if any returns nil
+                     ;; TODO: Unpack its rv into ... (We can't do this, ... is special)
+                     ;; If there is :override, then don't run the body
+                     (let [rv# (if (. _G (.. ,(tostring name) "__override"))
+                                 (let [ofunc# (. _G (.. ,(tostring name) "__override"))]
+                                   (ofunc# (table.unpack ,args)))
+                                 (do ,...))]
+                       ;; Call :after funcs
+                       (if (. _G (.. ,(tostring name) "__after"))
+                         (let [afunc# (. _G (.. ,(tostring name) "__after"))]
+                           (afunc# (table.unpack ,args))))
+                       ;; TODO: Call :after-while funcs if rv is not nil
+                       rv#
+                       )))))
+
+(fn defadvice!
+  [name args docstring where funcname ...]
+  "defadvice! defines an advising function and adds it to the specified function."
+  `(do
+     (let [add-advice!# (. (require "lib/utils") "add-advice!")]
+     (global ,name (fn ,args ,docstring ,...))
+     (add-advice!# ,funcname
+                  ,where ,name))))
+
+{: advisable-fn
+ : defadvice!}


### PR DESCRIPTION
WIP implementing #72

Some test code

```lisp
(local utils (require "lib/utils"))
(fn before-advice [...]
  (print "before-advice! Got args" ...))
(fn override-advice [...]
  (print "override-advice! Got args" ...)
  (print "Returning our own value")
  1000)
(fn around-advice [func ...]
  (print "around-advice! Got func " func)
  (print "Got args" ...)
  (print "Returning our own value")
  2000)

(import-macros {: advisable-fn : defadvice!} "macros")
(advisable-fn testfunc [a1 a2] "testdocstring"
              (print "Advisable func! Got args" a1 a2)
              (print "Returning sum")
              (+ a1 a2))


(utils.add-advice! "testfunc" :before before-advice)
;; (utils.add-advice! "testfunc" :override override-advice)
(utils.add-advice! "testfunc" :around around-advice)
(defadvice! myadvice [...]
            "test advice"
            :after "testfunc"
            (print "After! got args" ...))
(global rem utils.remove-advice!)
```