### PR TITLE
Advising System

### DIFF
--- a/core.fnl
+++ b/core.fnl
@@ -55,6 +55,8 @@ Returns nil. This function causes side-effects.
 
 (global fw hs.window.focusedWindow)
 
+(global pprint (fn [x] (print (fennel.view x))))
+
 (fn file-exists?
   [filepath]
   "

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -832,6 +832,14 @@ performance overhead may be noticeably chuggy.
 Just like with emacs, use advisable functions cautiously when it's the
 best choice for users to customize behaviors.
 
+** Tables vs. Functions
+
+The =make-advisable= function and =defadvice= macro return tables with a
+=__call=, =__index=, and =__name= metatable entries. The resulting tables
+can be called just like functions, but if you run =(type
+defn-func-2-advice)= it may return  "table" instead of function. If
+this causes any issues, please report it so we can consider alternatives.
+
 * Prior Art
 
 This concept was directly inspired and arguably ripped-off of emacs'

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -59,8 +59,8 @@ Example:
 ;; => "over-it"
 #+end_src
 
-- defn-func-override completely overrides defn-func-4
-- When calling defn-func-4, defn-func-override is called instead
+- =defn-func-override= completely overrides =defn-func-4=
+- When calling =defn-func-4=, =defn-func-override= is called instead
   returning "over-it" instead of "default"
 
 The defadvice call above expands to:
@@ -463,6 +463,7 @@ Example:
 (original-fn 1 2 3)
 ;; => 10 ;; Values returned by advice-fn applied to original-fn
 #+end_src
+
 ** filter-return
 
 The advising function is called with the return value of the original

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -30,11 +30,11 @@ Usage:
       )
 #+end_src
 
-- ~"docstr"~ is always required for advisable functions, it's a best
+- ="docstr"= is always required for advisable functions, it's a best
   practice for root module functions and will help guide people who
   wish to advise it.
 
-- At least one body form is required. If stubbing out a function ~nil~
+- At least one body form is required. If stubbing out a function =nil=
   will do just fine. This is a requirement that comes from the fennel
   =(fn)= special form.
 
@@ -80,7 +80,7 @@ functions, but =afn= covers the use cases where =defn= will not work.
 ** afn
 
 The afn macro supports inline functions defined as callback arguments
-to higher-order-functions or when creating bespoke functions in ~let~ forms.
+to higher-order-functions or when creating bespoke functions in =let= forms.
 
 Usage:
 
@@ -181,7 +181,7 @@ That key is a unique pointer to an advisable function. It can be
 passed as the target to both the =defadvice= macro and =add-advice=
 function. It is always calculated from the =~/.hammerspoon= root, if you
 are creating advisable functions within your =~/.spacehammer= directory,
-the keys will start with ~"spacehammer"~.
+the keys will start with ="spacehammer"=.
 
 The following forms are equivalent:
 
@@ -218,7 +218,7 @@ Advice can be defined before the advisable function exists:
 *** defadvice
 
 The =defadvice= macro should be the primary means for adding advice but
-a direct ~add-advice~ alternative is available.
+a direct =add-advice= alternative is available.
 
 Usage:
 
@@ -232,11 +232,11 @@ Usage:
   )
 #+end_src
 
-- The string keyword ~:override~ refers to one of many advice types
+- The string keyword =:override= refers to one of many advice types
   described below.
 - The advisor-function-name makes it easier to track advice later
 - A docstr is required
-- At least one body form is required, ~nil~ may be used for noop and
+- At least one body form is required, =nil= may be used for noop and
   placeholder functions
 
 Example:
@@ -275,7 +275,7 @@ The defadvice call above expands to:
 
 *** add-advice
 
-If in the event =defadvice= macro does not work, the ~add-advice~ function
+If in the event =defadvice= macro does not work, the =add-advice= function
 may be better suited. It's what =defadvice= uses under the hood.
 
 Usage:

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -76,12 +76,12 @@ The defadvice call above expands to:
 #+end_src
 
 =defadvice= is best used in top-level calls within a module so that
-they can be removed if needed latter.
+they can be removed if needed later.
 
 *** add-advice
 
-If in the event =defadvice= macro does not work, the =add-advice= function
-may be better suited. It's what =defadvice= uses under the hood.
+If the =defadvice= macro does not suit your needs, the =add-advice= function
+may prove a helpful alternative. It's what =defadvice= uses under the hood.
 
 Usage:
 
@@ -311,11 +311,12 @@ Example:
 
 (original-fn 1 2 3)
 ;; => true ;; advice-fn returned truthy value, original not called
+#+end_src
 
 ** after
 
 Call a function after the original function with the same arguments.
-The return value of the advised function is discarded as it executes side-effects.
+Only the original function's return value is returned
 
 Behavior:
 
@@ -345,6 +346,7 @@ Example:
 (original-fn 1 2 3)
 ;; => 6 ;; original fn prints the sum
 ;; => 4 ;; advice fn called after, its value returned
+#+end_src
 
 ** after-while
 
@@ -383,6 +385,7 @@ Example:
 
 (original-fn 1 2 3)
 ;; => 6 ;; Original-fn returned truthy value, advice-fn called
+#+end_src
 
 ** after-until
 
@@ -422,6 +425,7 @@ Example:
 
 (original-fn 1 2 3)
 ;; => true ;; original-fn returned truthy vaue, advice-fn not called
+#+end_src
 
 ** filter-args
 
@@ -458,8 +462,7 @@ Example:
 
 (original-fn 1 2 3)
 ;; => 10 ;; Values returned by advice-fn applied to original-fn
-
-
+#+end_src
 ** filter-return
 
 The advising function is called with the return value of the original
@@ -496,6 +499,8 @@ Example:
 
 (original-fn 1 2 3)
 ;; => 12 ;; Return value of original-fn passed to advice-fn
+#+end_src
+
 
 * Advising Targets and Order
 
@@ -582,7 +587,7 @@ Usage:
       )
 #+end_src
 
-- ="docstr"= is always required for advisable functions, it's a best
+- =docstr= is always required for advisable functions, it's a best
   practice for root module functions and will help guide people who
   wish to advise it.
 
@@ -821,14 +826,15 @@ Which would print something like:
 
 ** Performance
 
-Creating advisable functions and iterating through the composed advice
-that can be added does come with some overhead. For the purposes of
-spacehammer it should be negligible but if you find it bogging your
-system down, please create an issue so we can investigate.
+Creating advisable functions does come with some runtime overhead
+iterating through the advice. In most cases the performance hit should
+be negligible,  but if anyone does experience unexpected performance
+issues please report it so maintainers can investigate.
 
-It's not advisable (pun not intended but happily discovered) to make
-animation functions advisable intended to run every few ms as the
-performance overhead may be noticeably chuggy.
+For example, functions that run in a short interval like an animation
+function that fires every 5 milliseconds, may experience degraded
+performance if made advisable due to the overhead caused by
+dispatching advice every time they fire.
 
 ** Complexity
 

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -2,16 +2,17 @@
 
 * What is it?
 
-Inspired by emacs, the advising system allows SpaceHammer developers
-to define functions that users can hook to run operations before,
-after, wrap, or replace the original implementation. This gives users
-the flexibility to customize behavior without having to create
-extraneous config.fnl options.
+Inspired by emacs, the advising system provides an API for defining
+core functions that users can then customize by adding hooks in the
+form of other functions that can override, wrap, run before, run
+after, among other behaviors. Instead of limiting users to a few
+config options maintainers and contributors provide, users can
+customize core behaviors however they would like.
 
 * Defining an Advisable Function
 
 Unlike emacs, functions are not advisable by default, in fennel, the
-=defn= and =afn= macros can define advisable functions.
+=defn= and =afn= macros were created to define advisable functions.
 
 ** defn
 
@@ -162,177 +163,6 @@ Example:
 ;; => "default"
 
 #+end_src
-
-* Adding Advice
-
-With an advisable function created, we can now add advice to extend
-the behaviors. This section will cover the APIs to add advice, and the
-next section will cover the supported advice types.
-
-** Function references or strings
-
-The add advice APIs accept both a target function or the unique key
-pointing to an advisable function entry. Only functions defined with
-=defn=, =afn=, or =make-advisable= are supported.
-
-For example, if this fennel code was in the []:
-
-#+begin_src fennel
-(import-macros {: defn} :lib.advice.macros)
-
-(defn defn-func-2
-      [x y z]
-      "docstr"
-      "default")
-
-(print defn-func-2.key)
-#+end_src
-
-It would print the following:
-
-#+begin_src fennel
-"test/advice-test/defn-func-2"
-#+end_src
-
-That key is a unique pointer to an advisable function. It can be
-passed as the target to both the =defadvice= macro and =add-advice=
-function. It is always calculated from the =~/.hammerspoon= root, if you
-are creating advisable functions within your =~/.spacehammer= directory,
-the keys will start with ="spacehammer"=.
-
-The following forms are equivalent:
-
-#+begin_src fennel
-(add-advice defn-func-2 :override (fn [x y z] "over-it"))
-(add-advice :test/advice-test/defn-func-2 :override (fn [x y z] "over-it"))
-#+end_src
-
-** Order does not matter
-
-Advice can be defined before the advisable function exists:
-
-#+begin_src fennel
-(import-macros {: defn
-                : defadvice} :lib.advice.macros)
-
-(defadvice defn-func-override
-           [x y z]
-           :override defn-func-3
-           "Overrides defn-func-3"
-           "over-it")
-
-(defn defn-func-3
-      [x y z]
-      "docstr"
-      "Hi")
-
-(defn-func-3)
-;; => "over-it"
-#+end_src
-
-** Advising APIs
-
-*** defadvice
-
-The =defadvice= macro should be the primary means for adding advice but
-a direct =add-advice= alternative is available.
-
-Usage:
-
-#+begin_src fennel
-(defadvice advisor-function-name
-  [x y z]
-  :override target-function-or-key
-  "docstr"
-  body-1
-  ...body ;; Optional
-  )
-#+end_src
-
-- The string keyword =:override= refers to one of many advice types
-  described below.
-- The advisor-function-name makes it easier to track advice later
-- A docstr is required
-- At least one body form is required, =nil= may be used for noop and
-  placeholder functions
-
-Example:
-
-#+begin_src fennel
-(defn defn-func-4
-      [x y z]
-      "docstr"
-      "default")
-
-(defadvice defn-func-override
-           [x y z]
-           :override defn-func-4
-           "Overrides defn-func-4"
-           "over-it")
-
-(defn-func-4)
-;; => "over-it"
-#+end_src
-
-- defn-func-override completely overrides defn-func-4
-- When defn-func-4 is called, defn-func-override is called instead
-  returning "over-it" instead of "default"
-
-The defadvice call above expands to:
-
-#+begin_src fennel
-(local defn-func-override
-       (let [adv_0_ (require "lib.advice")
-             advice-fn_0_ (fn defn-func-override
-                            [x y z]
-                            "Overrides defn-func-4" "over-it")]
-         (adv_0_.add-advice defn-func-4 "override" advice-fn_0_)
-         advice-fn_0_))
-#+end_src
-
-=defadvice= is best used in top-level calls within a module so that
-they can be removed if needed latter.
-
-*** add-advice
-
-If in the event =defadvice= macro does not work, the =add-advice= function
-may be better suited. It's what =defadvice= uses under the hood.
-
-Usage:
-
-#+begin_src fennel
-(add-advice target-function-or-key :advice-type advice-function)
-#+end_src
-
-- target-function-or-key refers to advisable-fn.key or the string itself
-- :advice-type refers to one of many advice types described below
-- advice-function depends on the advice type as it will receive
-  different args along with different expected return types
-
-Example:
-
-#+begin_src fennel
-(import-macros {: defn
-                : defadvice} :lib.advice.macros)
-(local {: add-advice} :lib.advice)
-
-(defn defn-func-5
-      [x y z]
-      "docstr"
-      "default")
-
-(add-advice defn-func-5
-            :override (fn [x y z]
-                        "over-it"))
-
-(defn-func-5)
-;; => "over-it"
-#+end_src
-
-- Identical behavior to the =defadvice= behavior described above, but a
-  more primitive API.
-- It's recommended to use =defadvice= most of the time as it enforces
-  better habits that will keep projects from becoming a mess.
 
 * Advise Types
 
@@ -711,6 +541,177 @@ Example:
 
 (original-fn 1 2 3)
 ;; => 12 ;; Return value of original-fn passed to advice-fn
+
+* Adding Advice
+
+With an advisable function created, we can now add advice to extend
+the behaviors. This section will cover the APIs to add advice, and the
+next section will cover the supported advice types.
+
+** Advising APIs
+
+*** defadvice
+
+The =defadvice= macro should be the primary means for adding advice but
+a direct =add-advice= alternative is available.
+
+Usage:
+
+#+begin_src fennel
+(defadvice advisor-function-name
+  [x y z]
+  :override target-function-or-key
+  "docstr"
+  body-1
+  ...body ;; Optional
+  )
+#+end_src
+
+- The string keyword =:override= refers to one of many advice types
+  described below.
+- The advisor-function-name makes it easier to track advice later
+- A docstr is required
+- At least one body form is required, =nil= may be used for noop and
+  placeholder functions
+
+Example:
+
+#+begin_src fennel
+(defn defn-func-4
+      [x y z]
+      "docstr"
+      "default")
+
+(defadvice defn-func-override
+           [x y z]
+           :override defn-func-4
+           "Overrides defn-func-4"
+           "over-it")
+
+(defn-func-4)
+;; => "over-it"
+#+end_src
+
+- defn-func-override completely overrides defn-func-4
+- When defn-func-4 is called, defn-func-override is called instead
+  returning "over-it" instead of "default"
+
+The defadvice call above expands to:
+
+#+begin_src fennel
+(local defn-func-override
+       (let [adv_0_ (require "lib.advice")
+             advice-fn_0_ (fn defn-func-override
+                            [x y z]
+                            "Overrides defn-func-4" "over-it")]
+         (adv_0_.add-advice defn-func-4 "override" advice-fn_0_)
+         advice-fn_0_))
+#+end_src
+
+=defadvice= is best used in top-level calls within a module so that
+they can be removed if needed latter.
+
+*** add-advice
+
+If in the event =defadvice= macro does not work, the =add-advice= function
+may be better suited. It's what =defadvice= uses under the hood.
+
+Usage:
+
+#+begin_src fennel
+(add-advice target-function-or-key :advice-type advice-function)
+#+end_src
+
+- target-function-or-key refers to advisable-fn.key or the string itself
+- :advice-type refers to one of many advice types described below
+- advice-function depends on the advice type as it will receive
+  different args along with different expected return types
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+(local {: add-advice} :lib.advice)
+
+(defn defn-func-5
+      [x y z]
+      "docstr"
+      "default")
+
+(add-advice defn-func-5
+            :override (fn [x y z]
+                        "over-it"))
+
+(defn-func-5)
+;; => "over-it"
+#+end_src
+
+- Identical behavior to the =defadvice= behavior described above, but a
+  more primitive API.
+- It's recommended to use =defadvice= most of the time as it enforces
+  better habits that will keep projects from becoming a mess.
+
+** Function references or strings
+
+The add advice APIs accept both a target function or the unique key
+pointing to an advisable function entry. Only functions defined with
+=defn=, =afn=, or =make-advisable= are supported.
+
+For example, if this fennel code was in the []:
+
+#+begin_src fennel
+(import-macros {: defn} :lib.advice.macros)
+
+(defn defn-func-2
+      [x y z]
+      "docstr"
+      "default")
+
+(print defn-func-2.key)
+#+end_src
+
+It would print the following:
+
+#+begin_src fennel
+"test/advice-test/defn-func-2"
+#+end_src
+
+That key is a unique pointer to an advisable function. It can be
+passed as the target to both the =defadvice= macro and =add-advice=
+function. It is always calculated from the =~/.hammerspoon= root, if you
+are creating advisable functions within your =~/.spacehammer= directory,
+the keys will start with ="spacehammer"=.
+
+The following forms are equivalent:
+
+#+begin_src fennel
+(add-advice defn-func-2 :override (fn [x y z] "over-it"))
+(add-advice :test/advice-test/defn-func-2 :override (fn [x y z] "over-it"))
+#+end_src
+
+** Order does not matter
+
+Advice can be defined before the advisable function exists:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defadvice defn-func-override
+           [x y z]
+           :override defn-func-3
+           "Overrides defn-func-3"
+           "over-it")
+
+(defn defn-func-3
+      [x y z]
+      "docstr"
+      "Hi")
+
+(defn-func-3)
+;; => "over-it"
+#+end_src
 
 * Other Useful APIs
 

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -9,160 +9,115 @@ after, among other behaviors. Instead of limiting users to a few
 config options maintainers and contributors provide, users can
 customize core behaviors however they would like.
 
-* Defining an Advisable Function
+* Adding Advice
 
-Unlike emacs, functions are not advisable by default, in fennel, the
-=defn= and =afn= macros were created to define advisable functions.
+Maintainers and contributors define core functions as advisable using
+the =defn= and =afn= macros described at the bottom of this document. Most
+people will use the advising APIs below to customize behavior to their liking.
 
-** defn
+** Advising APIs
 
-The defn macro works like =fn= except that it only works for
-module-level locals, it will not work for ad-hoc functions created
-within a =let= form.
+*** defadvice
 
-Usage:
-
-#+begin_src fennel
-(defn function-name
-      [args]
-      "docstr"
-      body-1
-      ...body ;; Optional
-      )
-#+end_src
-
-- ="docstr"= is always required for advisable functions, it's a best
-  practice for root module functions and will help guide people who
-  wish to advise it.
-
-- At least one body form is required. If stubbing out a function =nil=
-  will do just fine. This is a requirement that comes from the fennel
-  =(fn)= special form.
-
-
-Example:
-
-#+begin_src fennel
-(import-macros {: defn
-                : defadvice} :lib.advice.macros)
-
-(defn defn-func-1
-      [x y z]
-      "docstr"
-      "Hi")
-
-(defn-func-1)
-;; => "Hi"
-
-(defadvice defn-func-override
-           [x y z]
-           :override defn-func-1
-           "Overrides defn-func-1"
-           "over-it")
-
-(defn-func-1)
-;; => "over-it"
-#+end_src
-
-The =defn= macro transforms the above call into the following:
-
-#+begin_src fennel
-(local defn-func-1
-       (let [adv_0_ (require "lib.advice")]
-         (adv_0_.make-advisable
-          "defn-func-2" (fn [x y z]
-                          "docstr"
-                          "hi"))))
-#+end_src
-
-The =defn= macro should be the primary API for creating advisable
-functions, but =afn= covers the use cases where =defn= will not work.
-
-** afn
-
-The afn macro supports inline functions defined as callback arguments
-to higher-order-functions or when creating bespoke functions in =let= forms.
+The =defadvice= macro should be the primary means for adding advice but
+a direct =add-advice= alternative is available.
 
 Usage:
 
 #+begin_src fennel
-(afn function-name
-     [args]
-     body-1
-     ...body ;; Optional
-     )
-#+end_src
-
-- It's nearly identical to =defn= but the docstr is not supported.
-- At least one function body form is required. Can be =nil= if trying to
-  make a noop or placeholder function.
-
-Example:
-
-#+begin_src fennel
-(import-macros {: afn
-                : defadvice} :lib.advice.macros)
-
-(let [scoped-func (afn scoped-func
-                       [x y z]
-                       "default")]
-  (scoped-func)
-  ;; => "default"
-
-  (defadvice scoped-func-advice
-    [x y z]
-    :override scoped-func
-    "Overrides scoped-func"
-    "over-it")
-
-  (scoped-func)
-  ;; => "over-it"
-
+(defadvice advisor-function-name
+  [x y z]
+  :override target-function-or-key
+  "docstr"
+  body-1
+  ...body ;; Optional
   )
 #+end_src
 
-The =afn= macro transforms the above call into:
+- The string keyword =:override= refers to one of many advice types
+  described below.
+- The advisor-function-name makes it easier to track advice later
+- A docstr is required
+- At least one body form is required, =nil= may be used for noop and
+  placeholder functions
+
+Example:
 
 #+begin_src fennel
-(let [adv_0_ (require "lib.advice")]
-  (adv_0_.make-advisable
-   "priv-func"
-   (fn [x y z]
-     "default")))
+(defn defn-func-4
+      [x y z]
+      "docstr"
+      "default")
+
+(defadvice defn-func-override
+           [x y z]
+           :override defn-func-4
+           "Overrides defn-func-4"
+           "over-it")
+
+(defn-func-4)
+;; => "over-it"
 #+end_src
 
-** make-advisable
+- defn-func-override completely overrides defn-func-4
+- When calling defn-func-4, defn-func-override is called instead
+  returning "over-it" instead of "default"
 
-Lastly if macros are not an option for whatever reason, they mostly
-wrap the =make-advisable= function.
+The defadvice call above expands to:
+
+#+begin_src fennel
+(local defn-func-override
+       (let [adv_0_ (require "lib.advice")
+             advice-fn_0_ (fn defn-func-override
+                            [x y z]
+                            "Overrides defn-func-4" "over-it")]
+         (adv_0_.add-advice defn-func-4 "override" advice-fn_0_)
+         advice-fn_0_))
+#+end_src
+
+=defadvice= is best used in top-level calls within a module so that
+they can be removed if needed latter.
+
+*** add-advice
+
+If in the event =defadvice= macro does not work, the =add-advice= function
+may be better suited. It's what =defadvice= uses under the hood.
 
 Usage:
 
 #+begin_src fennel
-(make-advisable "unique key"
-  (fn [args]
-    body-1
-    ...body ;; Optional
-  ))
+(add-advice target-function-or-key :advice-type advice-function)
 #+end_src
+
+- target-function-or-key refers to advisable-fn.key or the string itself
+- :advice-type refers to one of many advice types described below
+- advice-function depends on the advice type as it will receive
+  different args along with different expected return types
 
 Example:
 
 #+begin_src fennel
 (import-macros {: defn
                 : defadvice} :lib.advice.macros)
-(local {: make-advisable} :lib.advice)
+(local {: add-advice} :lib.advice)
 
-(local advisable
-       (make-advisable
-        :advisable
-        (fn [x y z]
-          "default")))
+(defn defn-func-5
+      [x y z]
+      "docstr"
+      "default")
 
-(advisable)
-;; => "default"
+(add-advice defn-func-5
+            :override (fn [x y z]
+                        "over-it"))
 
+(defn-func-5)
+;; => "over-it"
 #+end_src
+
+- Identical behavior to the =defadvice= behavior described above, but a
+  more primitive API.
+- It's recommended to use =defadvice= most of the time as it enforces
+  better habits that will keep projects from becoming a mess.
 
 * Advise Types
 
@@ -542,115 +497,7 @@ Example:
 (original-fn 1 2 3)
 ;; => 12 ;; Return value of original-fn passed to advice-fn
 
-* Adding Advice
-
-With an advisable function created, we can now add advice to extend
-the behaviors. This section will cover the APIs to add advice, and the
-next section will cover the supported advice types.
-
-** Advising APIs
-
-*** defadvice
-
-The =defadvice= macro should be the primary means for adding advice but
-a direct =add-advice= alternative is available.
-
-Usage:
-
-#+begin_src fennel
-(defadvice advisor-function-name
-  [x y z]
-  :override target-function-or-key
-  "docstr"
-  body-1
-  ...body ;; Optional
-  )
-#+end_src
-
-- The string keyword =:override= refers to one of many advice types
-  described below.
-- The advisor-function-name makes it easier to track advice later
-- A docstr is required
-- At least one body form is required, =nil= may be used for noop and
-  placeholder functions
-
-Example:
-
-#+begin_src fennel
-(defn defn-func-4
-      [x y z]
-      "docstr"
-      "default")
-
-(defadvice defn-func-override
-           [x y z]
-           :override defn-func-4
-           "Overrides defn-func-4"
-           "over-it")
-
-(defn-func-4)
-;; => "over-it"
-#+end_src
-
-- defn-func-override completely overrides defn-func-4
-- When defn-func-4 is called, defn-func-override is called instead
-  returning "over-it" instead of "default"
-
-The defadvice call above expands to:
-
-#+begin_src fennel
-(local defn-func-override
-       (let [adv_0_ (require "lib.advice")
-             advice-fn_0_ (fn defn-func-override
-                            [x y z]
-                            "Overrides defn-func-4" "over-it")]
-         (adv_0_.add-advice defn-func-4 "override" advice-fn_0_)
-         advice-fn_0_))
-#+end_src
-
-=defadvice= is best used in top-level calls within a module so that
-they can be removed if needed latter.
-
-*** add-advice
-
-If in the event =defadvice= macro does not work, the =add-advice= function
-may be better suited. It's what =defadvice= uses under the hood.
-
-Usage:
-
-#+begin_src fennel
-(add-advice target-function-or-key :advice-type advice-function)
-#+end_src
-
-- target-function-or-key refers to advisable-fn.key or the string itself
-- :advice-type refers to one of many advice types described below
-- advice-function depends on the advice type as it will receive
-  different args along with different expected return types
-
-Example:
-
-#+begin_src fennel
-(import-macros {: defn
-                : defadvice} :lib.advice.macros)
-(local {: add-advice} :lib.advice)
-
-(defn defn-func-5
-      [x y z]
-      "docstr"
-      "default")
-
-(add-advice defn-func-5
-            :override (fn [x y z]
-                        "over-it"))
-
-(defn-func-5)
-;; => "over-it"
-#+end_src
-
-- Identical behavior to the =defadvice= behavior described above, but a
-  more primitive API.
-- It's recommended to use =defadvice= most of the time as it enforces
-  better habits that will keep projects from becoming a mess.
+* Advising Targets and Order
 
 ** Function references or strings
 
@@ -711,6 +558,161 @@ Advice can be defined before the advisable function exists:
 
 (defn-func-3)
 ;; => "over-it"
+#+end_src
+
+* Defining an Advisable Function
+
+Unlike emacs, functions are not advisable by default, in fennel, the
+=defn= and =afn= macros were created to define advisable functions.
+
+** defn
+
+The defn macro works like =fn= except that it only works for
+module-level locals, it will not work for ad-hoc functions created
+within a =let= form.
+
+Usage:
+
+#+begin_src fennel
+(defn function-name
+      [args]
+      "docstr"
+      body-1
+      ...body ;; Optional
+      )
+#+end_src
+
+- ="docstr"= is always required for advisable functions, it's a best
+  practice for root module functions and will help guide people who
+  wish to advise it.
+
+- At least one body form is required. If stubbing out a function =nil=
+  will do just fine. This is a requirement that comes from the fennel
+  =(fn)= special form.
+
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn defn-func-1
+      [x y z]
+      "docstr"
+      "Hi")
+
+(defn-func-1)
+;; => "Hi"
+
+(defadvice defn-func-override
+           [x y z]
+           :override defn-func-1
+           "Overrides defn-func-1"
+           "over-it")
+
+(defn-func-1)
+;; => "over-it"
+#+end_src
+
+The =defn= macro transforms the above call into the following:
+
+#+begin_src fennel
+(local defn-func-1
+       (let [adv_0_ (require "lib.advice")]
+         (adv_0_.make-advisable
+          "defn-func-2" (fn [x y z]
+                          "docstr"
+                          "hi"))))
+#+end_src
+
+The =defn= macro should be the primary API for creating advisable
+functions, but =afn= covers the use cases where =defn= will not work.
+
+** afn
+
+The afn macro supports inline functions defined as callback arguments
+to higher-order-functions or when creating bespoke functions in =let= forms.
+
+Usage:
+
+#+begin_src fennel
+(afn function-name
+     [args]
+     body-1
+     ...body ;; Optional
+     )
+#+end_src
+
+- It's nearly identical to =defn= but the docstr is not supported.
+- At least one function body form is required. Can be =nil= if trying to
+  make a noop or placeholder function.
+
+Example:
+
+#+begin_src fennel
+(import-macros {: afn
+                : defadvice} :lib.advice.macros)
+
+(let [scoped-func (afn scoped-func
+                       [x y z]
+                       "default")]
+  (scoped-func)
+  ;; => "default"
+
+  (defadvice scoped-func-advice
+    [x y z]
+    :override scoped-func
+    "Overrides scoped-func"
+    "over-it")
+
+  (scoped-func)
+  ;; => "over-it"
+
+  )
+#+end_src
+
+The =afn= macro transforms the above call into:
+
+#+begin_src fennel
+(let [adv_0_ (require "lib.advice")]
+  (adv_0_.make-advisable
+   "priv-func"
+   (fn [x y z]
+     "default")))
+#+end_src
+
+** make-advisable
+
+Lastly if macros are not an option for whatever reason, they mostly
+wrap the =make-advisable= function.
+
+Usage:
+
+#+begin_src fennel
+(make-advisable "unique key"
+  (fn [args]
+    body-1
+    ...body ;; Optional
+  ))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+(local {: make-advisable} :lib.advice)
+
+(local advisable
+       (make-advisable
+        :advisable
+        (fn [x y z]
+          "default")))
+
+(advisable)
+;; => "default"
+
 #+end_src
 
 * Other Useful APIs

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -1,0 +1,450 @@
+#+title: Advising API
+
+* What is it?
+
+Inspired by emacs, the advising system allows SpaceHammer developers
+to define functions that users can hook to run operations before,
+after, wrap, or replace the original implementation. This gives users
+the flexibility to customize behavior without having to create
+extraneous config.fnl options.
+
+* Defining an Advisable Function
+
+Unlike emacs, functions are not advisable by default, in fennel, the
+=defn= and =afn= macros can define advisable functions.
+
+** defn
+
+The defn macro works like =fn= except that it only works for
+module-level locals, it will not work for ad-hoc functions created
+within a =let= form.
+
+Usage:
+
+#+begin_src fennel
+(defn function-name
+      [args]
+      "docstr"
+      body-1
+      ...body ;; Optional
+      )
+#+end_src
+
+- ~"docstr"~ is always required for advisable functions, it's a best
+  practice for root module functions and will help guide people who
+  wish to advise it.
+
+- At least one body form is required. If stubbing out a function ~nil~
+  will do just fine. This is a requirement that comes from the fennel
+  =(fn)= special form.
+
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn defn-func-1
+      [x y z]
+      "docstr"
+      "Hi")
+
+(defn-func-1)
+;; => "Hi"
+
+(defadvice defn-func-override
+           [x y z]
+           :override defn-func-1
+           "Overrides defn-func-1"
+           "over-it")
+
+(defn-func-1)
+;; => "over-it"
+#+end_src
+
+The =defn= macro transforms the above call into the following:
+
+#+begin_src fennel
+(local defn-func-1
+       (let [adv_0_ (require "lib.advice")]
+         (adv_0_.make-advisable
+          "defn-func-2" (fn [x y z]
+                          "docstr"
+                          "hi"))))
+#+end_src
+
+The =defn= macro should be the primary API for creating advisable
+functions, but =afn= covers the use cases where =defn= will not work.
+
+** afn
+
+The afn macro supports inline functions defined as callback arguments
+to higher-order-functions or when creating bespoke functions in ~let~ forms.
+
+Usage:
+
+#+begin_src fennel
+(afn function-name
+     [args]
+     body-1
+     ...body ;; Optional
+     )
+#+end_src
+
+- It's nearly identical to =defn= but the docstr is not supported.
+- At least one function body form is required. Can be =nil= if trying to
+  make a noop or placeholder function.
+
+Example:
+
+#+begin_src fennel
+(import-macros {: afn
+                : defadvice} :lib.advice.macros)
+
+(let [scoped-func (afn scoped-func
+                       [x y z]
+                       "default")]
+  (scoped-func)
+  ;; => "default"
+
+  (defadvice scoped-func-advice
+    [x y z]
+    :override scoped-func
+    "Overrides scoped-func"
+    "over-it")
+
+  (scoped-func)
+  ;; => "over-it"
+
+  )
+#+end_src
+
+The =afn= macro transforms the above call into:
+
+#+begin_src fennel
+(let [adv_0_ (require "lib.advice")]
+  (adv_0_.make-advisable
+   "priv-func"
+   (fn [x y z]
+     "default")))
+#+end_src
+
+** make-advisable
+
+Lastly if macros are not an option for whatever reason, they mostly
+wrap the =make-advisable= function.
+
+Usage:
+
+#+begin_src fennel
+(make-advisable "unique key"
+  (fn [args]
+    body-1
+    ...body ;; Optional
+  ))
+#+end_src
+
+
+* Adding Advice
+
+With an advisable function created, we can now add advice to extend
+the behaviors. This section will cover the APIs to add advice, and the
+next section will cover the supported advice types.
+
+** Function references or strings
+
+The add advice APIs accept both a target function or the unique key
+pointing to an advisable function entry. Only functions defined with
+=defn=, =afn=, or =make-advisable= are supported.
+
+For example, if this fennel code was in the []:
+
+#+begin_src fennel
+(import-macros {: defn} :lib.advice.macros)
+
+(defn defn-func-2
+      [x y z]
+      "docstr"
+      "default")
+
+(print defn-func-2.key)
+#+end_src
+
+It would print the following:
+
+#+begin_src fennel
+"test/advice-test/defn-func-2"
+#+end_src
+
+That key is a unique pointer to an advisable function. It can be
+passed as the target to both the =defadvice= macro and =add-advice=
+function. It is always calculated from the =~/.hammerspoon= root, if you
+are creating advisable functions within your =~/.spacehammer= directory,
+the keys will start with ~"spacehammer"~.
+
+The following forms are equivalent:
+
+#+begin_src fennel
+(add-advice defn-func-2 :override (fn [x y z] "over-it"))
+(add-advice :test/advice-test/defn-func-2 :override (fn [x y z] "over-it"))
+#+end_src
+
+** Order does not matter
+
+Advice can be defined before the advisable function exists:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defadvice defn-func-override
+           [x y z]
+           :override defn-func-3
+           "Overrides defn-func-3"
+           "over-it")
+
+(defn defn-func-3
+      [x y z]
+      "docstr"
+      "Hi")
+
+(defn-func-3)
+;; => "over-it"
+#+end_src
+
+** Advising APIs
+
+*** defadvice
+
+The =defadvice= macro should be the primary means for adding advice but
+a direct ~add-advice~ alternative is available.
+
+Usage:
+
+#+begin_src fennel
+(defadvice advisor-function-name
+  [x y z]
+  :override target-function-or-key
+  "docstr"
+  body-1
+  ...body ;; Optional
+  )
+#+end_src
+
+- The string keyword ~:override~ refers to one of many advice types
+  described below.
+- The advisor-function-name makes it easier to track advice later
+- A docstr is required
+- At least one body form is required, ~nil~ may be used for noop and
+  placeholder functions
+
+Example:
+
+#+begin_src fennel
+(defn defn-func-4
+      [x y z]
+      "docstr"
+      "default")
+
+(defadvice defn-func-override
+           [x y z]
+           :override defn-func-4
+           "Overrides defn-func-4"
+           "over-it")
+
+(defn-func-4)
+;; => "over-it"
+#+end_src
+
+- defn-func-override completely overrides defn-func-4
+- When defn-func-4 is called, defn-func-override is called instead
+  returning "over-it" instead of "default"
+
+The defadvice call above expands to:
+
+#+begin_src fennel
+(let [adv_0_ (require "lib.advice")]
+  (adv_0_.add-advice
+   defn-func-override
+   "override"
+   (fn defn-func-4 [x y z]
+     "Overrides defn-func-4"
+     "over-it")))
+#+end_src
+
+*** add-advice
+
+If in the event =defadvice= macro does not work, the ~add-advice~ function
+may be better suited. It's what =defadvice= uses under the hood.
+
+Usage:
+
+#+begin_src fennel
+(add-advice target-function-or-key :advice-type advice-function)
+#+end_src
+
+- target-function-or-key refers to advisable-fn.key or the string itself
+- :advice-type refers to one of many advice types described below
+- advice-function depends on the advice type as it will receive
+  different args along with different expected return types
+
+Example:
+
+#+begin_src fennel
+(defn defn-func-5
+      [x y z]
+      "docstr"
+      "default")
+
+(add-advice defn-func-5
+            :override (fn [x y z]
+                        "over-it"))
+
+(defn-func-5)
+;; => "over-it"
+#+end_src
+
+- Identical behavior to the =defadvice= behavior described above, but a
+  more primitive API.
+- It's recommended to use =defadvice= most of the time as it enforces
+  better habits that will keep projects from becoming a mess.
+
+* Advise Types
+
+This doc exclusively showcases the =override= advice-type but there are
+many more to choose from. Each will receive a different set of args,
+expect a different return type, and may fire at different times during
+the execution cycle.
+
+** override
+
+Replaces the target function and receives the arguments the original
+function was called with. May return any value but be mindful of what
+callers are expecting.
+
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (advice-function (table.unpack [...])))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn defn-func-6
+      [x y z]
+      "docstr"
+      "Hi")
+
+(defadvice defn-func-override
+           [x y z]
+           :override defn-func-6
+           "Overrides defn-func-6"
+           "over-it")
+
+(defn-func-6)
+;; => "over-it"
+#+end_src
+
+** around
+
+Wraps the target function and receives the original function as the
+first value followed by the arguments the original function was called
+with. This is the best choice for customizing the modal behavior in
+the spacehammer menu because it allows you to customize the arguments
+provided to the lower-level alert API but does not require a full
+re-implementation. This advise-type is the most versatile.
+
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (advice-function original-function (table.unpack [...])))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn defn-func-7
+      [x y z]
+      "docstr"
+      "Good job,")
+
+(defadvice defn-func-around
+           [orig-fn x y z]
+           :around defn-func-7
+           "Wraps defn-func-6"
+           ;; May call orig-fn anytime, maybe even more than once
+           ;; and retur
+           (.. (orig-fn x y z) " me"))
+
+(defn-func-7)
+;; => "Good job, me"
+#+end_src
+
+** before
+
+Call a function before the original function with the same arguments.
+Return value is discarded from the advising function.
+
+** before-while
+
+Call a function before the original function with the same arguments.
+If the return value of the advising function is truthy, it will also
+call the original function with the same arguments. If the return
+value is falsey, the original function will not be called.
+
+** before-until
+
+Call a function before the original function with the same arguments.
+If the return value of the advising function is falsey, it will then
+call the original function with the same arguments. If the return
+value is truthy, the original function will not be called. It behaves
+like the inverse of =before-while=.
+
+** after
+
+Call a function after the original function with the same arguments.
+The return value of the advised function is discarded as it is
+intended for performing side-effects.
+
+** after-while
+
+Calls the original function first, if it returns a truthy value the
+advising function is also called with the same arguments and its
+return value is what the caller receives.
+
+** after-until
+
+Calls the original function first, if it returns a falsey value the
+advising function is also called with the same arguments and its
+return value is what the caller receives. It behaves like the inverse
+of =after-while=.
+
+** filter-args
+
+The advising function is called with the args provided by the caller,
+it must return a table list of args to apply to the original function.
+It is used for transforming arguments, similar to around but without
+having access to the original.
+
+** filter-return
+
+The advising function is called with the return value of the original
+function. It may transform the return value and return the transformed
+value to the caller. It is also similar to around but without access
+to the original.
+
+* Prior Art
+
+This concept was directly inspired and arguably ripped-off of emacs'
+advising system. Much of their docs are relevant to this, if you would
+like to dig deeper check out the official [[emacs advising docs][https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html]]

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -383,11 +383,11 @@ Example:
            :around defn-func-7
            "Wraps defn-func-6"
            ;; May call orig-fn anytime, maybe even more than once
-           ;; and retur
-           (.. (orig-fn x y z) " me"))
+           ;; and return anything
+           (.. "Yay! " (orig-fn x y z) " me"))
 
 (defn-func-7)
-;; => "Good job, me"
+;; => "Yay! Good job, me"
 #+end_src
 
 ** before

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -145,6 +145,23 @@ Usage:
   ))
 #+end_src
 
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+(local {: make-advisable} :lib.advice)
+
+(local advisable
+       (make-advisable
+        :advisable
+        (fn [x y z]
+          "default")))
+
+(advisable)
+;; => "default"
+
+#+end_src
 
 * Adding Advice
 
@@ -264,14 +281,17 @@ Example:
 The defadvice call above expands to:
 
 #+begin_src fennel
-(let [adv_0_ (require "lib.advice")]
-  (adv_0_.add-advice
-   defn-func-override
-   "override"
-   (fn defn-func-4 [x y z]
-     "Overrides defn-func-4"
-     "over-it")))
+(local defn-func-override
+       (let [adv_0_ (require "lib.advice")
+             advice-fn_0_ (fn defn-func-override
+                            [x y z]
+                            "Overrides defn-func-4" "over-it")]
+         (adv_0_.add-advice defn-func-4 "override" advice-fn_0_)
+         advice-fn_0_))
 #+end_src
+
+=defadvice= is best used in top-level calls within a module so that
+they can be removed if needed latter.
 
 *** add-advice
 
@@ -292,6 +312,10 @@ Usage:
 Example:
 
 #+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+(local {: add-advice} :lib.advice)
+
 (defn defn-func-5
       [x y z]
       "docstr"
@@ -313,9 +337,9 @@ Example:
 * Advise Types
 
 This doc exclusively showcases the =override= advice-type but there are
-many more to choose from. Each will receive a different set of args,
-expect a different return type, and may fire at different times during
-the execution cycle.
+more to choose from. Each will receive a different set of args, expect
+a different return type, and may fire at different times during the
+execution cycle.
 
 ** override
 
@@ -327,7 +351,7 @@ Behavior:
 
 #+begin_src fennel
 (fn [...]
-  (advice-function (table.unpack [...])))
+  (advice-fn (table.unpack [...])))
 #+end_src
 
 Example:
@@ -336,18 +360,18 @@ Example:
 (import-macros {: defn
                 : defadvice} :lib.advice.macros)
 
-(defn defn-func-6
+(defn original-fn
       [x y z]
       "docstr"
       "Hi")
 
-(defadvice defn-func-override
+(defadvice advice-fn
            [x y z]
-           :override defn-func-6
-           "Overrides defn-func-6"
+           :override original-fn
+           "Overrides original-fn"
            "over-it")
 
-(defn-func-6)
+(original-fn)
 ;; => "over-it"
 #+end_src
 
@@ -364,7 +388,7 @@ Behavior:
 
 #+begin_src fennel
 (fn [...]
-  (advice-function original-function (table.unpack [...])))
+  (advice-fn original-function (table.unpack [...])))
 #+end_src
 
 Example:
@@ -373,20 +397,20 @@ Example:
 (import-macros {: defn
                 : defadvice} :lib.advice.macros)
 
-(defn defn-func-7
+(defn original-fn
       [x y z]
       "docstr"
       "Good job,")
 
-(defadvice defn-func-around
+(defadvice advice-fn
            [orig-fn x y z]
-           :around defn-func-7
-           "Wraps defn-func-6"
+           :around original-fn
+           "Wraps original-fn"
            ;; May call orig-fn anytime, maybe even more than once
            ;; and return anything
            (.. "Yay! " (orig-fn x y z) " me"))
 
-(defn-func-7)
+(original-fn)
 ;; => "Yay! Good job, me"
 #+end_src
 
@@ -395,12 +419,74 @@ Example:
 Call a function before the original function with the same arguments.
 Return value is discarded from the advising function.
 
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (advice-fn   (table.unpack [...]))
+  (original-fn (table.unpack [...])))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      (+ x y z))
+
+(defadvice advice-fn
+           [x y z]
+           :before original-fn
+           "Before original-fn"
+           (print "before:" (hs.inspect [x y z])))
+
+(original-fn 1 2 3)
+;; => "before: [1 2 3]"  ;; Before hook printing args
+;; => 6                  ;; Original function sum
+#+end_src
+
 ** before-while
 
 Call a function before the original function with the same arguments.
 If the return value of the advising function is truthy, it will also
 call the original function with the same arguments. If the return
 value is falsey, the original function will not be called.
+
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (and (advice-fn   (table.unpack [...]))
+       (original-fn (table.unpack [...]))))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      (+ x y z))
+
+(original-fn 1 2 3)
+;; => 6
+
+(defadvice advice-fn
+           [x y z]
+           :before-while original-fn
+           "Before-while original-fn"
+           nil)
+
+(original-fn 1 2 3)
+;; => nil ;; Original function was not called, advice fn returned nil
+#+end_src
 
 ** before-until
 
@@ -410,17 +496,108 @@ call the original function with the same arguments. If the return
 value is truthy, the original function will not be called. It behaves
 like the inverse of =before-while=.
 
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (or (advice-fn   (table.unpack [...]))
+      (original-fn (table.unpack [...]))))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      (+ x y z))
+
+(original-fn 1 2 3)
+;; => 6
+
+(defadvice advice-fn
+           [x y z]
+           :before-until original-fn
+           "Before-until original-fn"
+           true)
+
+(original-fn 1 2 3)
+;; => true ;; advice-fn returned truthy value, original not called
+
 ** after
 
 Call a function after the original function with the same arguments.
-The return value of the advised function is discarded as it is
-intended for performing side-effects.
+The return value of the advised function is discarded as it executes side-effects.
+
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (original-fn (table.unpack [...]))
+  (advice-fn   (table.unpack [...])))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      (print (+ x y z)))
+
+(defadvice advice-fn
+           [x y z]
+           :after original-fn
+           "After original-fn"
+           (+ (- y x) z))
+
+(original-fn 1 2 3)
+;; => 6 ;; original fn prints the sum
+;; => 4 ;; advice fn called after, its value returned
 
 ** after-while
 
 Calls the original function first, if it returns a truthy value the
 advising function is also called with the same arguments and its
 return value is what the caller receives.
+
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (and
+   (original-fn (table.unpack [...]))
+   (advice-fn   (table.unpack [...]))))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      true)
+
+(original-fn 1 2 3)
+;; => true
+
+(defadvice advice-fn
+           [x y z]
+           :after-while original-fn
+           "After-while original-fn"
+           (+ x y z))
+
+(original-fn 1 2 3)
+;; => 6 ;; Original-fn returned truthy value, advice-fn called
 
 ** after-until
 
@@ -429,12 +606,74 @@ advising function is also called with the same arguments and its
 return value is what the caller receives. It behaves like the inverse
 of =after-while=.
 
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (or
+   (original-fn (table.unpack [...]))
+   (advice-fn   (table.unpack [...]))))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      true)
+
+(original-fn 1 2 3)
+;; => true
+
+(defadvice advice-fn
+           [x y z]
+           :after-until original-fn
+           "After-until original-fn"
+           (+ x y z))
+
+(original-fn 1 2 3)
+;; => true ;; original-fn returned truthy vaue, advice-fn not called
+
 ** filter-args
 
 The advising function is called with the args provided by the caller,
 it must return a table list of args to apply to the original function.
-It is used for transforming arguments, similar to around but without
-having access to the original.
+It transforms arguments, similar to around but without having access to the original.
+
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (original-fn (table.unpack (advice-fn (table.unpack [...])))))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      (+ x y z))
+
+(original-fn 1 2 3)
+;; => 6
+
+(defadvice advice-fn
+           [x y z]
+           :filter-args original-fn
+           "filter-args original-fn"
+           [(* x 2) (* y 2) (* z 2)])
+
+(original-fn 1 2 3)
+;; => 10 ;; Values returned by advice-fn applied to original-fn
+
 
 ** filter-return
 
@@ -443,8 +682,160 @@ function. It may transform the return value and return the transformed
 value to the caller. It is also similar to around but without access
 to the original.
 
+Behavior:
+
+#+begin_src fennel
+(fn [...]
+  (advice-fn (original-fn (table.unpack [...]))))
+#+end_src
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      (+ x y z))
+
+(original-fn 1 2 3)
+;; => 6
+
+(defadvice advice-fn
+           [sum]
+           :filter-return original-fn
+           "filter-return original-fn"
+           (* sum 2))
+
+(original-fn 1 2 3)
+;; => 12 ;; Return value of original-fn passed to advice-fn
+
+* Other Useful APIs
+
+** Remove Advice
+
+Given the nature of this project, users will most likely be dealing
+with original functions where as emacs you may have layers of packages
+that advise core emacs functions. Therefore it's unlikely that
+remove-advice will be widely used but it has its uses in testing and debugging.
+
+Usage:
+
+#+begin_src fennel
+(remove-advice original-fn :advice-type advice-fn)
+#+end_src
+
+- Args are the same as =add-advice=
+
+Example:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+(local {: remove-advice} :lib.advice)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      "default")
+
+(original-fn)
+;; => "default"
+
+(defadvice advice-fn
+           [x y z]
+           :override original-fn
+           "over-it")
+;; => "over-it"
+
+(remove-advice original-fn :override advice-fn)
+
+(original-fn)
+;; => "default'
+#+end_src
+
+** Get Advice For an Advisable Function
+
+When testing or debugging it may be useful to see the list of advice
+applied to an advisable function.
+
+The =get-advice= function will do just that:
+
+#+begin_src fennel
+(import-macros {: defn
+                : defadvice} :lib.advice.macros)
+(local {: get-advice} :lib.advice)
+
+(defn original-fn
+      [x y z]
+      "docstr"
+      "default")
+
+(defadvice advice-fn
+           [x y z]
+           :override original-fn
+           "over-it")
+
+(pprint (get-advice original-fn))
+#+end_src
+
+Will print a table like the following:
+
+#+begin_src fennel
+[
+ {:f    "advice-fn: 0x600000278c80"
+  :type "override"}
+]
+#+end_src
+
+** Log Advisable Functions
+
+It may be useful to see a list of advisable function keys. Use the
+=print-advisable-keys= function to print a nicely formatted list of
+advisable keys.
+
+Example:
+
+#+begin_src fennel
+(local {: print-advisable-keys} :lib.advice)
+
+(print-advisable-keys)
+#+end_src
+
+Which would print something like:
+
+#+begin_example
+:test/advice-test/test-func-1
+:test/advice-test/test-func-2
+:test/advice-test/test-func-3
+;; ...
+:test/advice-test/test-func-7
+#+end_example
+
+* Considerations
+
+** Performance
+
+Creating advisable functions and iterating through the composed advice
+that can be added does come with some overhead. For the purposes of
+spacehammer it should be negligible but if you find it bogging your
+system down, please create an issue so we can investigate.
+
+It's not advisable (pun not intended but happily discovered) to make
+animation functions advisable intended to run every few ms as the
+performance overhead may be noticeably chuggy.
+
+** Complexity
+
+Just like with emacs, use advisable functions cautiously when it's the
+best choice for users to customize behaviors.
+
 * Prior Art
 
 This concept was directly inspired and arguably ripped-off of emacs'
 advising system. Much of their docs are relevant to this, if you would
-like to dig deeper check out the official [[emacs advising docs][https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html]]
+like to dig deeper check out the official [[emacs advising
+docs][https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html]]
+for more information.

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -89,9 +89,9 @@ Usage:
 (add-advice target-function-or-key :advice-type advice-function)
 #+end_src
 
-- target-function-or-key refers to advisable-fn.key or the string itself
-- :advice-type refers to one of many advice types described below
-- advice-function depends on the advice type as it will receive
+- =target-function-or-key= refers to advisable-fn.key or the string itself
+- =:advice-type= refers to one of many advice types described below
+- =advice-function= depends on the advice type as it will receive
   different args along with different expected return types
 
 Example:
@@ -832,10 +832,10 @@ iterating through the advice. In most cases the performance hit should
 be negligible,  but if anyone does experience unexpected performance
 issues please report it so maintainers can investigate.
 
-For example, functions that run in a short interval like an animation
-function that fires every 5 milliseconds, may experience degraded
-performance if made advisable due to the overhead caused by
-dispatching advice every time they fire.
+Functions that fire on a short interval, such as animation functions
+that run every 5 milliseconds, may encounter degraded performance
+caused by the advising overhead. It's not recommended to make
+functions like that advisable.
 
 ** Complexity
 

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -534,7 +534,7 @@ That key is a unique pointer to an advisable function. It can be
 passed as the target to both the =defadvice= macro and =add-advice=
 function. It is always calculated from the =~/.hammerspoon= root, if you
 are creating advisable functions within your =~/.spacehammer= directory,
-the keys will start with ="spacehammer"=.
+the keys will start with =spacehammer=.
 
 The following forms are equivalent:
 
@@ -854,6 +854,5 @@ this causes any issues, please report it so we can consider alternatives.
 
 This concept was directly inspired and arguably ripped-off of emacs'
 advising system. Much of their docs are relevant to this, if you would
-like to dig deeper check out the official [[emacs advising
-docs][https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html]]
-for more information.
+like to dig deeper check out the official [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html][emacs advice docs]] for more
+information.

--- a/docs/advice.org
+++ b/docs/advice.org
@@ -844,11 +844,12 @@ best choice for users to customize behaviors.
 
 ** Tables vs. Functions
 
-The =make-advisable= function and =defadvice= macro return tables with a
-=__call=, =__index=, and =__name= metatable entries. The resulting tables
-can be called just like functions, but if you run =(type
-defn-func-2-advice)= it may return  "table" instead of function. If
-this causes any issues, please report it so we can consider alternatives.
+The =make-advisable= function and =defadvice= macro return tables with
+a =__call=, =__index=, and =__name= metatable entries. The resulting
+tables can be called just like functions, but if you run
+=(type defn-func-2-advice)= it may return  "table" instead of
+function. If this causes any issues, please report it so we can
+consider alternatives.
 
 * Prior Art
 

--- a/lib/advice/init.fnl
+++ b/lib/advice/init.fnl
@@ -1,0 +1,205 @@
+;; Copyright (c) 2017-2020 Ag Ibragimov & Contributors
+;;
+;;; Author: Jay Zawrotny <jayzawrotny@gmail.com>
+;;
+;;; URL: https://github.com/agzam/spacehammer
+;;
+;;; License: MIT
+;;
+
+"
+Advising API to register functions
+"
+
+(require-macros :lib.macros)
+(local fennel (require :fennel))
+(local {: contains?
+        : compose
+        : filter
+        : first
+        : join
+        : last
+        : map
+        : reduce
+        : seq
+        : slice
+        : split} (require :lib.functional))
+
+(var advice {})
+(var advisable [])
+
+(fn add-advice
+  [f advice-type advice-fn]
+  (let [key (or f.key f)
+        advice-entry (. advice key)]
+    (when advice-entry
+      (table.insert advice-entry.advice {:type advice-type :f advice-fn}))))
+
+(fn remove-advice
+  [advice-type f]
+  (let [key f.key
+        advice-entry (. advice key)]
+    (tset advice-entry :advice
+          (->> advice-entry.advice
+               (filter #(not (and (= $1.type  advice-type)
+                                  (= $1.f     f))))))
+    nil))
+
+(fn register-advisable
+  [key f]
+  ;; @TODO Replace with if-let or similar macro but doesn't work in an isolated fennel file
+  (when (contains? key advisable)
+    (error (.. "Advisable function" key "already exists")))
+  (table.insert advisable key)
+  (let [advice-entry (. advice key)]
+    (if advice-entry
+        advice-entry
+        (tset advice key
+              {:original f
+               :advice []}))))
+
+(fn advisable-keys
+  []
+  (slice 0 advisable))
+
+(fn print-advisable-keys
+  []
+  (print "\nAdvisable functions:\n")
+  (each [i key (ipairs (advisable-keys))]
+    (print (.. "  :" key))))
+
+(fn get-module-name
+  []
+  (->> (. (debug.getinfo 3 "S") :short_src)
+       (split "/")
+       (slice -1)
+       (join "/")
+       (split "%.")
+       (first)))
+
+(fn advisor
+  [type f orig-f]
+  (if
+   (= type :override)
+   (fn [args]
+     (f (table.unpack args)))
+
+   (= type :around)
+   (fn [args]
+     (f orig-f (table.unpack args)))
+
+   (= type :before)
+   (fn [args]
+     (f (table.unpack args))
+     (orig-f (table.unpack args)))
+
+   (= type :before-while)
+   (fn [args]
+     (and (f (table.unpack args))
+          (orig-f (table.unpack args))))
+
+   (= type :before-until)
+   (fn [args]
+     (or (f (table.unpack args))
+         (orig-f (table.unpack args))))
+
+   (= type :after)
+   (fn [args]
+     (orig-f (table.unpack args))
+     (f (table.unpack args)))
+
+
+   (= type :after-while)
+   (fn [args]
+     (and (orig-f (table.unpack args))
+          (f (table.unpack args))))
+
+   (= type :after-until)
+   (fn [args]
+     (or (orig-f (table.unpack args))
+         (f (table.unpack args))))
+
+   (= type :filter-args)
+   (fn [args]
+     (orig-f (table.unpack (f (table.unpack args)))))
+
+   (= type :filter-return)
+   (fn [args]
+     (f (orig-f (table.unpack args))))))
+
+(fn apply-advice
+  [entry args]
+  (((compose
+     (table.unpack (->> entry.advice
+                        (map (fn [{: f
+                                   : type}]
+                               (fn [next-f]
+                                 (advisor type f next-f)))))))
+    (fn [...] (entry.original (table.unpack [...]))))
+   args))
+
+(fn count
+  [tbl]
+  (->> tbl
+       (reduce (fn [acc _x _key]
+                 (+ acc 1))
+               0)))
+
+(fn dispatch-advice
+  [key [_tbl & args]]
+  (let [entry (. advice key)]
+    (if (> (count entry.advice) 0)
+        (do
+          (apply-advice entry args))
+        (do
+          (entry.original (table.unpack args))))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Public API
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(fn make-advisable
+  [fn-name f]
+  "
+  Registers a function name against the global advisable table that contains
+  advice registered for a function. Advice can be defined before a function is
+  defined making it a really safe way to extend behavior without exploding
+  config options.
+
+  Usage:
+  (make-advisable :some-func (fn some-func [] \"Some return string\"))
+
+  - Supports passing some-func directly into add-advice
+  - Supports passing in some-func.key directly into add-advice
+  - Supports passing in a string like :path/to/module/some-func to add-advice
+  "
+  (let [module (get-module-name)
+        key (.. module "/" fn-name)
+        advice-reg (register-advisable key f)
+        ret {:key key}]
+    (setmetatable ret
+                  {:__call (fn [...]
+                             (dispatch-advice key [...]))
+                   :__index (fn [tbl key]
+                              (. tbl key))})
+    (each [k v (pairs (or (. fennel.metadata f) []))]
+      (: fennel.metadata :set ret k v))
+    ret))
+
+(fn reset
+  []
+  (set advice {})
+  (set advisable []))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Exports
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+{: reset
+ : make-advisable
+ : add-advice
+ : remove-advice
+ : advisable-keys
+ : print-advisable-keys}

--- a/lib/advice/init.fnl
+++ b/lib/advice/init.fnl
@@ -177,7 +177,8 @@ Advising API to register functions
         advice-reg (register-advisable key f)
         ret {:key key}]
     (setmetatable ret
-                  {:__call (fn [...]
+                  {:__name fn-name
+                   :__call (fn [...]
                              (dispatch-advice key [...]))
                    :__index (fn [tbl key]
                               (. tbl key))})
@@ -232,6 +233,18 @@ Advising API to register functions
   (each [i key (ipairs (advisable-keys))]
     (print (.. "  :" key))))
 
+(fn get-advice
+  [f-or-key]
+  "
+  Returns the advice list for a given function or advice entry key
+  "
+  (let [advice-entry (. advice (or f-or-key.key f-or-key))]
+    (if advice-entry
+        (map
+         (fn [adv]
+           {:f (tostring adv.f) :type adv.type})
+         (slice 0 advice-entry.advice))
+        [])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Exports
@@ -241,4 +254,5 @@ Advising API to register functions
  : make-advisable
  : add-advice
  : remove-advice
+ : get-advice
  : print-advisable-keys}

--- a/lib/advice/init.fnl
+++ b/lib/advice/init.fnl
@@ -100,9 +100,9 @@ Advising API to register functions
 
    (= type :after)
    (fn [args]
-     (orig-f (table.unpack args))
-     (f (table.unpack args)))
-
+     (let [ret (orig-f (table.unpack args))]
+       (f (table.unpack args))
+       ret))
 
    (= type :after-while)
    (fn [args]

--- a/lib/advice/macros.fnl
+++ b/lib/advice/macros.fnl
@@ -52,18 +52,28 @@ Macros to create advisable functions or register advice for advisable functions
 
 
 (fn defadvice
-  [f-or-key args advice-type fn-name docstr body1 ...]
+  [fn-name args advice-type f-or-key docstr body1 ...]
   "
   Define advice for an advisable function. Syntax sugar for calling
   (add-advice key-or-advisable-fn (fn [] ...))
 
   @example
-
+  (defadvice my-advice-fn
+    [x y z]
+    :override original-fn
+    \"Override original-fn\"
+    (* x y z))
   "
   (assert (= (type docstr) :string) "A docstr is required for defining advice")
   (assert body1 "advisable function expected body")
-  `(let [adv# (require :lib.advice)]
-     (adv#.add-advice ,f-or-key ,advice-type (fn ,fn-name ,args ,docstr ,body1 ,...))))
+  `(local ,fn-name
+          (let [adv# (require :lib.advice)
+                advice-fn# (setmetatable
+                            {}
+                            {:__name ,(tostring fn-name)
+                             :__call (fn ,fn-name ,args ,docstr ,body1 ,...)})]
+            (adv#.add-advice ,f-or-key ,advice-type advice-fn#)
+            advice-fn#)))
 
 {: afn
  : defn

--- a/lib/advice/macros.fnl
+++ b/lib/advice/macros.fnl
@@ -1,0 +1,70 @@
+;; Copyright (c) 2017-2020 Ag Ibragimov & Contributors
+;;
+;;; Author: Jay Zawrotny <jayzawrotny@gmail.com>
+;;
+;;; URL: https://github.com/agzam/spacehammer
+;;
+;;; License: MIT
+;;
+
+"
+Macros to create advisable functions or register advice for advisable functions
+"
+
+(fn defn
+  [fn-name args docstr body1 ...]
+  "
+  Define an advisable function, typically as a module-level function.
+  Can be advised with the defadvice macro or add-advice function
+
+  @example
+  (defn greeting
+    [name]
+    \"Advisable greeting function\"
+    (print \"Hello\" name))
+  "
+  (assert (= (type docstr) :string) "A docstr required for advisable functions")
+  (assert body1 "advisable function expected body")
+  (let [fn-name-str (tostring fn-name)]
+    `(local ,fn-name
+            (let [adv# (require :lib.advice)]
+              (adv#.make-advisable ,fn-name-str (fn ,args ,docstr ,body1 ,...))))))
+
+(fn afn
+  [fn-name args body1 ...]
+  "
+  Define an advisable function in as a function expression. These should be used
+  with caution to support when an API function is created from another parent
+  function call.
+
+  @example
+  (let [f (afn local-greeting
+            [name]
+            \"Advisable greeting but local to this scope\")
+            (print \"Hello\" name)]
+    (f))
+  "
+  (assert body1 "advisable function expected body")
+  (let [fn-name-str (tostring fn-name)]
+    `(let [adv# (require :lib.advice)]
+       (adv#.make-advisable ,fn-name-str (fn ,args ,body1 ,...)))))
+
+
+
+(fn defadvice
+  [f-or-key args advice-type fn-name docstr body1 ...]
+  "
+  Define advice for an advisable function. Syntax sugar for calling
+  (add-advice key-or-advisable-fn (fn [] ...))
+
+  @example
+
+  "
+  (assert (= (type docstr) :string) "A docstr is required for defining advice")
+  (assert body1 "advisable function expected body")
+  `(let [adv# (require :lib.advice)]
+     (adv#.add-advice ,f-or-key ,advice-type (fn ,fn-name ,args ,docstr ,body1 ,...))))
+
+{: afn
+ : defn
+ : defadvice}

--- a/test/advice-test.fnl
+++ b/test/advice-test.fnl
@@ -101,13 +101,14 @@
                             "Advisable test function"
                             (let [args [...]]
                               (tset state :args (.. state.args " " (join " " (map #(+ $1 2) [...])))))
-                            (tset state :calls (+ state.calls 1))))]
+                            (tset state :calls (+ state.calls 1))
+                            "original"))]
 
            (add-advice test-func :before (fn [...]
                                            (let [args [...]]
                                              (tset state :args (join " " [...])))
                                            (tset state :calls (+ state.calls 1))))
-           (test-func 1 2)
+           (is.eq? (test-func 1 2) "original" "Before test-func did not return original return value")
            (is.eq? state.calls 2 "Before test-func did not call both the original and before fn")
            (is.eq? state.args "1 2 3 4" "Before test-func did not call both the original and before with the same args"))))
 
@@ -199,7 +200,7 @@
                                            (let [args [...]]
                                              (tset state :args (.. state.args " " (join " " (map #(+ $1 2) [...])))))
                                            (tset state :calls (+ state.calls 1))))
-           (test-func 1 2)
+           (is.eq? (test-func 1 2) true "After did not return the original return value")
            (is.eq? state.calls 2 "After test-func did not call both the original and after fn")
            (is.eq? state.args "1 2 3 4" "After test-func did not call both the original and after with the same args"))))
 

--- a/test/advice-test.fnl
+++ b/test/advice-test.fnl
@@ -5,6 +5,7 @@
         : make-advisable
         : add-advice
         : remove-advice
+        : get-advice
         : print-advisable-keys} (require :lib.advice))
 
 (local fennel (require :fennel))
@@ -335,10 +336,47 @@
                "docstr"
                (print "hi"))
 
-         (defadvice defn-func-2 [x y z]
-                    :override defn-override
+         (defadvice defn-func-2-advice [x y z]
+                    :override defn-func-2
                     "Override defn-func-2 with this sweet, sweet syntax sugar"
                     "This feature is done!")
 
          (is.eq? (defn-func-2) "This feature is done!" "defadvice did not advise defn-func-2")))
+
+   (it "Should support advice added with defadvice"
+       (fn []
+         (defn defn-func-3
+               [x y z]
+               "docstr"
+               "default")
+
+         (is.eq? (defn-func-3) "default" "original-fn did not return default")
+
+         (defadvice defn-func-3-advice [x y z]
+                    :override defn-func-3
+                    "Override defn-func-3 with this sweet, sweet syntax sugar"
+                    "over-it")
+
+         (is.eq? (defn-func-3) "over-it" "defadvice did not advise defn-func-3")
+
+         (remove-advice defn-func-3 :override defn-func-3-advice)
+
+         (is.eq? (defn-func-3) "default" "advice was not removed from original-fn")))
+
+   (it "Should support get-advice returning the advice list for an advised func"
+       (fn []
+         (defn defn-func-4
+               [x y z]
+               "docstr"
+               "default")
+
+         (defadvice defn-func-4-advice [x y z]
+                    :override defn-func-4
+                    "Override defn-func-4"
+                    "over-it")
+
+         (is.eq? (defn-func-4) "over-it" "defn-func-4 was not advised")
+         (is.eq? (length (get-advice defn-func-4)) 1 "advice list should be 1")))
+
+
    ))

--- a/test/advice-test.fnl
+++ b/test/advice-test.fnl
@@ -1,0 +1,305 @@
+(import-macros {: defn
+                : afn
+                : defadvice} :lib.advice.macros)
+(local {: reset
+        : make-advisable
+        : add-advice
+        : advisable-keys
+        : print-advisable-keys} (require :lib.advice))
+
+(local fennel (require :fennel))
+(local is (require :lib.testing.assert))
+(local {: join
+        : map} (require :lib.functional))
+
+
+(describe
+ "Advice"
+ (fn []
+   (before reset)
+
+
+   (it "Should call unadvised functions as-is"
+       (fn []
+         (let [test-func (make-advisable
+                          :test-func-1
+                          (fn test-func-1 [arg]
+                            "Advisable test function"
+                            (.. "Hello " arg)))]
+
+           (is.eq? (test-func "cat") "Hello cat" "Unadvised test-func did not return \"Hello cat\""))))
+
+   (it "Should call override functions instead"
+       (fn []
+         (let [test-func (make-advisable
+                          :test-func-2
+                          (fn [...]
+                            "Advisable test function"
+                            "Plain pizza"))]
+
+           (add-advice test-func :override (fn [...] (.. "Overrided " (join " " [...]))))
+           (is.eq? (test-func "anchovie" "pizza") "Overrided anchovie pizza" "Override test-func did not return \"Overrided anchovie pizza\""))))
+
+   (it "Should call around functions with orig"
+       (fn []
+         (let [test-func (make-advisable
+                          :test-func-3
+                          (fn [...]
+                            "Advisable test function"
+                            ["old" (table.unpack [...])]))]
+
+           (add-advice test-func :around (fn [orig ...] (join " " ["around" (table.unpack (orig (table.unpack [...])))])))
+           (is.eq? (test-func "one" "two") "around old one two" "Around test-func did not return \"around one two old\""))))
+
+   (it "Should call before functions"
+       (fn []
+         (let [state {:calls 0
+                      :args ""}
+               test-func (make-advisable
+                          :test-func-4
+                          (fn [...]
+                            "Advisable test function"
+                            (let [args [...]]
+                              (tset state :args (.. state.args " " (join " " (map #(+ $1 2) [...])))))
+                            (tset state :calls (+ state.calls 1))))]
+
+           (add-advice test-func :before (fn [...]
+                                           (let [args [...]]
+                                             (tset state :args (join " " [...])))
+                                           (tset state :calls (+ state.calls 1))))
+           (test-func 1 2)
+           (is.eq? state.calls 2 "Before test-func did not call both the original and before fn")
+           (is.eq? state.args "1 2 3 4" "Before test-func did not call both the original and before with the same args"))))
+
+   (it "Should call orig if before-while returns truthy"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-5
+                          (fn [...]
+                            "Advisable test function"
+                            (.. "original " (join " " [...]))))]
+
+           (add-advice test-func
+                       :before-while
+                       (fn [...]
+                         (tset state :called true)
+                         true))
+           (is.eq? (test-func 1 2) "original 1 2" "Before-while test-func did not call original function")
+           (is.eq? state.called true "Before-while test-func advice function was not called"))))
+
+   (it "Should not call orig if before-while returns false"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-5b
+                          (fn [...]
+                            "Advisable test function"
+                            (.. "original " (join " " [...]))))]
+
+           (add-advice test-func
+                       :before-while
+                       (fn [...]
+                         (tset state :called true)
+                         false))
+           (is.eq? (test-func 1 2) false "Before-while test-func did call original function")
+           (is.eq? state.called true "Before-while test-func advice function was not called"))))
+
+
+   (it "Should call orig if before-until returns falsey value"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-6
+                          (fn [...]
+                            "Advisable test function"
+                            (.. "original " (join " " [...]))))]
+
+           (add-advice test-func
+                       :before-until
+                       (fn [...]
+                         (tset state :called true)
+                         false))
+           (is.eq? (test-func 1 2) "original 1 2" "Before-until test-func did not call original function")
+           (is.eq? state.called true "Before-until test-func advice function was not called"))))
+
+
+   (it "Should not call orig if before-until returns truthy value"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-6b
+                          (fn [...]
+                            "Advisable test function"
+                            (.. "original " (join " " [...]))))]
+
+           (add-advice test-func
+                       :before-until
+                       (fn [...]
+                         (tset state :called true)
+                         true))
+           (is.eq? (test-func 1 2) true "Before-until test-func did call original function")
+           (is.eq? state.called true "Before-until test-func advice function was not called"))))
+
+
+   (it "Should call after functions"
+       (fn []
+         (let [state {:calls 0
+                      :args ""}
+               test-func (make-advisable
+                          :test-func-7
+                          (fn [...]
+                            "Advisable test function"
+                            (let [args [...]]
+                              (tset state :args (join " " [...])))
+                            (tset state :calls (+ state.calls 1))
+                            true))]
+
+           (add-advice test-func :after (fn [...]
+                                           (let [args [...]]
+                                             (tset state :args (.. state.args " " (join " " (map #(+ $1 2) [...])))))
+                                           (tset state :calls (+ state.calls 1))))
+           (test-func 1 2)
+           (is.eq? state.calls 2 "After test-func did not call both the original and after fn")
+           (is.eq? state.args "1 2 3 4" "After test-func did not call both the original and after with the same args"))))
+
+
+   (it "Should call after-while if orig returns truthy"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-8
+                          (fn [...]
+                            "Advisable test function"
+                            (.. "original " (join " " [...]))))]
+
+           (add-advice test-func
+                       :after-while
+                       (fn [...]
+                         (tset state :called true)
+                         true))
+           (is.eq? (test-func 1 2) true "After-while test-func did not call original function")
+           (is.eq? state.called true "After-while test-func advice function was not called"))))
+
+   (it "Should not call after-while if orig returns falsey"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-8b
+                          (fn [...]
+                            "Advisable test function"
+                            false))]
+
+           (add-advice test-func
+                       :after-while
+                       (fn [...]
+                         (tset state :called true)
+                         true))
+           (is.eq? (test-func 1 2) false "After-while test-func did not call original function")
+           (is.eq? state.called false "After-while test-func advice function was called"))))
+
+
+
+   (it "Should call after-until if orig returns falsey value"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-9
+                          (fn [...]
+                            "Advisable test function"
+                            false))]
+
+           (add-advice test-func
+                       :after-until
+                       (fn [...]
+                         (tset state :called true)
+                         false))
+           (is.eq? (test-func 1 2) false "After-until test-func did not call original function")
+           (is.eq? state.called true "After-until test-func advice function was not called"))))
+
+   (it "Should not call after-until if orig returns truthy value"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-9b
+                          (fn [...]
+                            "Advisable test function"
+                            (.. "original " (join " " [...]))))]
+
+           (add-advice test-func
+                       :after-until
+                       (fn [...]
+                         (tset state :called true)
+                         false))
+           (is.eq? (test-func 1 2) "original 1 2" "After-until test-func did call advise function")
+           (is.eq? state.called false "After-until test-func advice function was called"))))
+
+   (it "Should filter args sent to orig function"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-10
+                          (fn [...]
+                            "Advisable test function"
+                            (.. "original " (join " " [...]))))]
+
+           (add-advice test-func
+                       :filter-args
+                       (fn [arg-1 arg-2]
+                         (tset state :called true)
+                         [ arg-2 ]))
+           (is.eq? (test-func 1 2) "original 2" "Filter-args test-func did call orig function with filtered-args")
+           (is.eq? state.called true "Filter-args test-func advice function was not called"))))
+
+   (it "Should filter the return value from orig function"
+       (fn []
+         (let [state {:called false}
+               test-func (make-advisable
+                          :test-func-11
+                          (fn [...]
+                            "Advisable test function"
+                            [ "original" (table.unpack [...])]))]
+
+           (add-advice test-func
+                       :filter-return
+                       (fn [[arg-1 arg-2 arg-3]]
+                         (tset state :called true)
+                         (.. "filtered " arg-2 " " arg-3)))
+           (is.eq? (test-func 1 2) "filtered 1 2" "Filter-return test-func did call advise with orig return")
+           (is.eq? state.called true "Filter-return test-func advice function was not called"))))
+
+
+   (it "Should support the defn macro for defining a function within a scope"
+       (fn []
+         (defn defn-func-1
+               [x y z]
+               "docstr"
+               (print "Hi"))
+
+         (add-advice defn-func-1 :override (fn [x y z] "over-it"))
+
+         (is.eq? (type defn-func-1) "table" "defn call did not result in a callable table")
+         (is.eq? (defn-func-1) "over-it" "defn function was not advised with override")))
+
+   (it "Should support the afn macro for defining inline functions"
+       (fn []
+         (let [priv-func (afn priv-func [x y z] "default")]
+           (add-advice priv-func :override (fn [x y z] "over-it"))
+
+           (is.eq? (type priv-func) "table" "afn did not result in a callable table")
+           (is.eq? (priv-func) "over-it" "afn function was not advised with override"))))
+
+   (it "Should support advice added with defadvice"
+       (fn []
+         (defn defn-func-2
+               [x y z]
+               "docstr"
+               (print "hi"))
+
+         (defadvice defn-func-2 [x y z]
+                    :override defn-override
+                    "Override defn-func-2 with this sweet, sweet syntax sugar"
+                    "This feature is done!")
+
+         (is.eq? (defn-func-2) "This feature is done!" "defadvice did not advise defn-func-2")))
+   ))


### PR DESCRIPTION
Provides a system to wrap or define advisable functions that can be overwritten later. See #72 for intended use case. 

Can solve a number of open PRs by allowing us to wrap some of the internals to support advising. Then users can customize the behaviors by adding advice to their liking. This helps us reduce the number of config settings we need to include for personal preferences.

For example:

We can make the main modal.fnl alert function advisable, then users can add advice to override it so that it displays on all monitors at the same time.

The work here depends on the testing work in #106.

Usage example:

```fennel
(import-macros {: defn
                : defadvice} :lib.advice.macros)

(defn original-fn
      [x y z]
      "docstr"
      "Hi")

(original-fn)
;; => "Hi"

(defadvice advice-fn
           [x y z]
           :override original-fn
           "Overrides original-fn"
           "over-it")

(original-fn)
;; => "over-it"
```


Closes #101 
Closes #72 

Test Results and feature list:

![image](https://user-images.githubusercontent.com/590297/131215394-d279c823-f5f9-4347-a9ea-d7fed0e46c9c.png)


## Credits

Big thanks to @Grazfather for getting a first draft out I could iterate on. We also paired a few weeks back and traded knowledge around this which helped a lot.