### PR TITLE
Update apps.fnl to support config for switcher filter

### DIFF
--- a/apps.fnl
+++ b/apps.fnl
@@ -26,15 +26,17 @@
         {: h} (: screen :currentMode)]
     (/ h 2)))
 
-(global switcher
-       (hs.window.switcher.new
-        (global-filter)
-        {:textSize 12
-         :showTitles false
-         :showThumbnails false
-         :showSelectedTitle false
-         :selectedThumbnailSize (calc-thumbnail-size)
-         :backgroundColor [0 0 0 0]}))
+(fn init
+  [config]
+  (global switcher
+          (hs.window.switcher.new
+           (or (?. config :modules :switcher :filter) (global-filter))
+           {:textSize 12
+            :showTitles false
+            :showThumbnails false
+            :showSelectedTitle false
+            :selectedThumbnailSize (calc-thumbnail-size)
+            :backgroundColor [0 0 0 0]})))
 
 (fn prev-app
   []
@@ -60,5 +62,6 @@
 ;; Exports
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-{:prev-app                prev-app
- :next-app                next-app}
+{: init
+ : prev-app
+ : next-app}

--- a/core.fnl
+++ b/core.fnl
@@ -199,6 +199,7 @@ Returns nil. This function causes side-effects.
 (local modules [:lib.hyper
                 :vim
                 :windows
+                :apps
                 :lib.bind
                 :lib.modal
                 :lib.apps])


### PR DESCRIPTION
Creates a config option for the window switcher in apps.fnl for custom window filters. Useful if you want the switcher to show minimized apps have other specific app states users wish to target.

## Why not use advice from #102?

The hs app switcher already takes a specialized API hs.window.filter instance so in this case wrapping it in an advisable function seems like indirection without adding much value. The hs.window.filter API is already reasonably well documented https://www.hammerspoon.org/docs/hs.window.filter.html.

Advice could be used if we run into more complex use cases. Or the apps.fnl init function could be made advisable if people wish to override it.

See #109 