### PR TITLE
Update repl.fnl to support fennel 0.10

### DIFF
--- a/repl.fnl
+++ b/repl.fnl
@@ -43,7 +43,7 @@
                                   (: :read "*all")
                                   (: :gsub "^#![^\n]*\n" "")))
                   (: f :close))
-    (f msg)))
+    _ (f msg)))
 
 (local default-opts
        {:port nil


### PR DESCRIPTION
Upgraded my fennel package from luarocks to 0.10 but ran into an error about repl.fnl due to the match macro not containing an even number of clauses. The docs suggested prefixing the default value with the key `_`.

Think you could take a quick look @Grazfather?