### PR TITLE
Make alert function advisable + fix advice lib

### DIFF
--- a/core.fnl
+++ b/core.fnl
@@ -23,6 +23,7 @@
         :split     split
         :some      some} (require :lib.functional))
 (require-macros :lib.macros)
+(require-macros :lib.advice.macros)
 
 ;; Make ~/.spacehammer folder override repo files
 (local homedir (os.getenv "HOME"))
@@ -47,11 +48,18 @@ Shortcut for showing an alert on the primary screen for a specified duration
 Takes a message string, a style table, and the number of seconds to show alert
 Returns nil. This function causes side-effects.
 "
-(global alert (fn [str style seconds]
-                (hs.alert.show str
-                               style
-                               (hs.screen.primaryScreen)
-                               seconds)))
+(global alert
+        (afn
+         alert
+         [str style seconds]
+         "
+         Global alert function used for spacehammer modals and reload
+         alerts after config reloads
+         "
+         (hs.alert.show str
+                        style
+                        (hs.screen.primaryScreen)
+                        seconds)))
 
 (global fw hs.window.focusedWindow)
 

--- a/lib/advice/init.fnl
+++ b/lib/advice/init.fnl
@@ -140,7 +140,7 @@ Advising API to register functions
                0)))
 
 (fn dispatch-advice
-  [entry [_tbl & args]]
+  [entry args]
   (if (> (count entry.advice) 0)
       (apply-advice entry args)
       (entry.original (table.unpack args))))
@@ -175,7 +175,7 @@ Advising API to register functions
              :advice advice-entry}]
     (setmetatable ret
                   {:__name fn-name
-                   :__call (fn [...]
+                   :__call (fn [_tbl ...]
                              (dispatch-advice advice-entry [...]))
                    :__index (fn [tbl key]
                               (. tbl key))})

--- a/lib/advice/macros.fnl
+++ b/lib/advice/macros.fnl
@@ -68,10 +68,12 @@ Macros to create advisable functions or register advice for advisable functions
   (assert body1 "advisable function expected body")
   `(local ,fn-name
           (let [adv# (require :lib.advice)
+                target-fn# (fn ,fn-name ,args ,docstr ,body1 ,...)
                 advice-fn# (setmetatable
                             {}
                             {:__name ,(tostring fn-name)
-                             :__call (fn ,fn-name ,args ,docstr ,body1 ,...)})]
+                             :__call (fn [_tbl# ...]
+                                       (target-fn# (table.unpack [...])))})]
             (adv#.add-advice ,f-or-key ,advice-type advice-fn#)
             advice-fn#)))
 

--- a/test/advice-test.fnl
+++ b/test/advice-test.fnl
@@ -33,12 +33,13 @@
        (fn []
          (let [test-func (make-advisable
                           :test-func-2
-                          (fn [...]
+                          (fn [x y z]
                             "Advisable test function"
-                            "Plain pizza"))]
+                            (+ x y z)))]
 
-           (add-advice test-func :override (fn [...] (.. "Overrided " (join " " [...]))))
-           (is.eq? (test-func "anchovie" "pizza") "Overrided anchovie pizza" "Override test-func did not return \"Overrided anchovie pizza\""))))
+           (is.eq? (test-func 1 2 3) 6 "Original function did not return 6")
+           (add-advice test-func :override (fn [x y z] (+ x y z 1)))
+           (is.eq? (test-func 1 2 3) 7 "Override advice did not return 7"))))
 
    (it "Should support advice added by string name"
        (fn []
@@ -48,7 +49,10 @@
                             "Advisable test function"
                             "Plain pizza"))]
 
-           (add-advice :test/advice-test/test-func-2b :override (fn [...] (.. "Overrided " (join " " [...]))))
+           (add-advice :test/advice-test/test-func-2b :override
+                       (fn [...]
+                         (is.eq? (length [...]) 2 "Override advice received more than 2 args")
+                         (.. "Overrided " (join " " [...]))))
            (is.eq? (test-func "anchovie" "pizza") "Overrided anchovie pizza" "Override test-func did not return \"Overrided anchovie pizza\""))))
 
    (it "Should call original when remove-advice is called"
@@ -344,6 +348,19 @@
 
          (is.eq? (defn-func-2) "This feature is done!" "defadvice did not advise defn-func-2")))
 
+   (it "Should support afn advice added with defadvice"
+       (fn []
+         (let [afn-func-2 (afn afn-func-2
+                               [x y z]
+                               "docstr"
+                               (+ x y z))]
+           (defadvice afn-func-2-advice [x y z]
+                      :override afn-func-2
+                      "Override afn-func-2 with this sweet, sweet syntax sugar"
+                      (+ x y z 1))
+
+           (is.eq? (afn-func-2 1 2 3) 7 "defadvice did not advise afn-func-2"))))
+
    (it "Should support advice added with defadvice"
        (fn []
          (defn defn-func-3
@@ -378,6 +395,21 @@
 
          (is.eq? (defn-func-4) "over-it" "defn-func-4 was not advised")
          (is.eq? (length (get-advice defn-func-4)) 1 "advice list should be 1")))
+
+   (it "Should support get-advice on afn advisable functions"
+       (fn []
+         (let [afn-func-3 (afn afn-func-3
+                               [x yz]
+                               "docstr"
+                               "default")]
+
+           (defadvice afn-func-3-advice [x y z]
+                      :override afn-func-3
+                      "Override afn-func-3"
+                      "over-it")
+
+           (is.eq? (afn-func-3) "over-it" "afn-func-3 was not advised")
+           (is.eq? (length (get-advice afn-func-3)) 1 "advice list should be 1"))))
 
 
    ))


### PR DESCRIPTION
Fixes a small inconsistency in the advice `defadvice` macro + makes the modal function advisable. Includes updates to the tests to catch issues like this in the future.

Fixes #74
Closes #75 
Closes #95 

Then you can add the following to your config.fnl:

```fennel
(require-macros :lib.advice.macros)

(defadvice alert-all-screens
           [str style seconds]
           :override alert
           "Displays an alert across all screens"
           (pprint {:str str
                    :style style
                    :seconds seconds})
           (each [key screen (ipairs (hs.screen.allScreens))]
             (hs.alert.show str
                            style
                            screen
                            seconds)))
```

Then the spacehammer modal will display on all screens. @Grazfather may create a follow up PR to add it to the docs as an official, practical example.

The exact cause was due to use the metatables to make the advisable functions callable while storing references to their advice entry and key.