### PR TITLE
Fix Center Window

### DIFF
--- a/core.fnl
+++ b/core.fnl
@@ -22,6 +22,7 @@
         :reduce    reduce
         :split     split
         :some      some} (require :lib.functional))
+(local atom (require :lib.atom))
 (require-macros :lib.macros)
 (require-macros :lib.advice.macros)
 
@@ -64,6 +65,14 @@ Returns nil. This function causes side-effects.
 (global fw hs.window.focusedWindow)
 
 (global pprint (fn [x] (print (fennel.view x))))
+
+(global get-config
+        (afn get-config
+          []
+          "
+          Returns the global config object, or error if called early
+          "
+          (error "get-config can only be called after all modules have initialized")))
 
 (fn file-exists?
   [filepath]
@@ -218,6 +227,12 @@ Returns nil. This function causes side-effects.
                 :lib.bind
                 :lib.modal
                 :lib.apps])
+
+(defadvice get-config-impl
+           []
+           :override get-config
+           "Returns global config obj"
+           config)
 
 ;; Create a global reference so services like hs.application.watcher
 ;; do not get garbage collected.

--- a/windows.fnl
+++ b/windows.fnl
@@ -10,19 +10,20 @@
 ;;; License: MIT
 ;;
 
-(local {:filter    filter
-        :get-in    get-in
-        :count     count
-        :concat    concat
-        :contains? contains?
-        :map       map
-        :for-each  for-each} (require :lib.functional))
+(local {: filter
+        : get-in
+        : count
+        : concat
+        : contains?
+        : map
+        : for-each
+        : split} (require :lib.functional))
 (local {:global-filter global-filter} (require :lib.utils))
 (local {:atom   atom
         :deref  deref
         :swap!  swap!
         :reset! reset!} (require :lib.atom))
-
+(require-macros :lib.advice.macros)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; History
@@ -89,15 +90,39 @@
   (: (hs.window.focusedWindow) :maximize 0)
   (highlight-active-window))
 
+(defn position-window-center
+      [ratio-str window]
+      "
+      Takes the center-ratio key from config, or default value if not
+      provided, and the window center-window-frame was called with.
+      Should calculate the centered dimensions of the target window
+      using the ratio values
+      This function is advisable.
+      "
+      (let [screen (hs.screen.primaryScreen)
+            frame (: screen :fullFrame)
+            [w-percent h-percent] (split ":" ratio-str)
+            w-percent (/ (tonumber w-percent) 100)
+            h-percent (/ (tonumber h-percent) 100)
+            update {:w (* w-percent frame.w)
+                    :h (* h-percent frame.h)
+                    :x 0
+                    :y 0}]
+        (doto window
+          (: :setFrameInScreenBounds update)
+          (: :centerOnScreen))
+        (highlight-active-window)))
+
 (fn center-window-frame
   []
   (: history :push)
-  (let [win (hs.window.focusedWindow)]
-    (: win :maximize 0)
-    (hs.grid.resizeWindowThinner win)
-    (hs.grid.resizeWindowShorter win)
-    (: win :centerOnScreen))
-  (highlight-active-window))
+  (let [win (hs.window.focusedWindow)
+        prev-duration hs.window.animationDuration
+        config (get-config)
+        ratio  (or config.modules.windows.center-ratio "80:50")]
+    (tset hs.window :animationDuration 0)
+    (position-window-center ratio win)
+    (tset hs.window :animationDuration prev-duration)))
 
 (fn activate-app
   [app-name]
@@ -501,39 +526,40 @@
 ;; Exports
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-{:activate-app            activate-app
- :center-window-frame     center-window-frame
- :enter-window-menu       enter-window-menu
- :exit-window-menu        exit-window-menu
- :hide-display-numbers    hide-display-numbers
- :highlight-active-window highlight-active-window
- :init                    init
- :jump                    jump
- :jump-to-last-window     jump-to-last-window
- :jump-window-above       jump-window-above
- :jump-window-below       jump-window-below
- :jump-window-left        jump-window-left
- :jump-window-right       jump-window-right
- :maximize-window-frame   maximize-window-frame
- :move-east               move-east
- :move-north              move-north
- :move-south              move-south
- :move-to-screen          move-to-screen
- :move-west               move-west
- :rect                    rect
- :resize-down             resize-down
- :resize-half-bottom      resize-half-bottom
- :resize-half-left        resize-half-left
- :resize-half-right       resize-half-right
- :resize-half-top         resize-half-top
- :resize-inc-bottom       resize-inc-bottom
- :resize-inc-left         resize-inc-left
- :resize-inc-right        resize-inc-right
- :resize-inc-top          resize-inc-top
- :resize-left             resize-left
- :resize-right            resize-right
- :resize-up               resize-up
- :set-mouse-cursor-at     set-mouse-cursor-at
- :show-display-numbers    show-display-numbers
- :show-grid               show-grid
- :undo-action             undo}
+{: activate-app
+ : center-window-frame
+ : enter-window-menu
+ : exit-window-menu
+ : hide-display-numbers
+ : highlight-active-window
+ : init
+ : jump
+ : jump-to-last-window
+ : jump-window-above
+ : jump-window-below
+ : jump-window-left
+ : jump-window-right
+ : maximize-window-frame
+ : move-east
+ : move-north
+ : move-south
+ : move-to-screen
+ : move-west
+ : position-window-center
+ : rect
+ : resize-down
+ : resize-half-bottom
+ : resize-half-left
+ : resize-half-right
+ : resize-half-top
+ : resize-inc-bottom
+ : resize-inc-left
+ : resize-inc-right
+ : resize-inc-top
+ : resize-left
+ : resize-right
+ : resize-up
+ : set-mouse-cursor-at
+ : show-display-numbers
+ : show-grid
+ : undo}


### PR DESCRIPTION
NOTE: This PR depends on #118. Once that is merged, I'll rebase to reduce noise.

Fixes #119 

Allows you to add something like the following to your config.fnl:

```fennel
{
  ;; ...
        :modules {:windows  {:center-ratio "50:60"}}
  ;; ...
}
```

Then you can use the center-window-frame window modal action to use it like the following:

![2021-09-12 19 09 24](https://user-images.githubusercontent.com/590297/133006116-a137c60a-3114-42fd-9140-9de7bca1cca3.gif)

Creates an advisable function called `windows.position-window-center` that takes the center-ratio config string and the target window. It is responsible for parsing the center-ratio string into numbers, and applying them to the target window. The advisable function gives users the option of overriding it to parse the center-ratio string in a different format and apply the calculation differently if needed.

If an option is not set, defaults to `80:50` which is a percentage of the screen. This is nearly identical to the previous version defaults.