### PR TITLE
Adds a couple of hooks to edit-with-emacs workflow

### DIFF
--- a/spacehammer.el
+++ b/spacehammer.el
@@ -75,6 +75,18 @@ DIRECTION - can be North, South, West, East"
     - pid         - PID of the app that invoked Edit-with-Emacs
     - title       - title of the app that invoked Edit-with-Emacs")
 
+(defvar spacehammer/before-finish-edit-with-emacs-hook nil
+  "Hook for when edit-with-emacs is finished and dedicated buffer and frame are about to get killed.
+   Hook function must accept arguments:
+    - buffer-name - the name of the edit buffer
+    - pid         - PID of the app that invoked Edit-with-Emacs")
+
+(defvar spacehammer/before-cancel-edit-with-emacs-hook nil
+  "Hook for when edit-with-emacs is canceled and dedicated buffer and frame are about to get killed.
+   Hook function must accept arguments:
+    - buffer-name - the name of the edit buffer
+    - pid         - PID of the app that invoked Edit-with-Emacs")
+
 (defun spacehammer/edit-with-emacs (&optional pid title screen)
   "Edit anything with Emacs
 
@@ -116,6 +128,11 @@ TITLE is a title of the window (the caller is responsible to set that right)"
 
 (defun spacehammer/finish-edit-with-emacs ()
   (interactive)
+  (run-hook-with-args
+   'spacehammer/before-finish-edit-with-emacs-hook
+   (buffer-name (current-buffer))
+   systemwide-edit-previous-app-pid)
+
   (clipboard-kill-ring-save (point-min) (point-max))
   (kill-buffer)
   (delete-frame)
@@ -125,6 +142,11 @@ TITLE is a title of the window (the caller is responsible to set that right)"
 
 (defun spacehammer/cancel-edit-with-emacs ()
   (interactive)
+  (run-hook-with-args
+   'spacehammer/before-cancel-edit-with-emacs-hook
+   (buffer-name (current-buffer))
+   systemwide-edit-previous-app-pid)
+
   (kill-buffer)
   (delete-frame)
   (spacehammer/switch-to-app systemwide-edit-previous-app-pid)


### PR DESCRIPTION
We already expose a hook for when edit-with-emacs starts, `spacehammer/edit-with-emacs-hook`

It gets called at the beginning of the edit and gives users a chance to set frame, buffer and other parameters, major and minor modes, e.g., one may want to set a "distraction free mode", or/and visual-line-mode, etc.

-----

These newly added hooks get called right before closing the edit frame and, for example, can be used like this:

    (defun spacehammer-before-finish-edit-with-emacs (bufname pid)
      (with-current-buffer bufname
        (set-buffer-modified-p nil)))

    (add-hook 'spacehammer/before-finish-edit-with-emacs-hook #'spacehammer-before-finish-edit-with-emacs)

In that particular snippet, we mark the buffer as unmodified, so Emacs wouldn't prompt, asking if the file needs saving. It doesn't usually do that (because Spacehammer, by default, doesn't designate a file). However, if in `spacehammer/edit-with-emacs-hook` we set a filename for the buffer, i.e.:

  (set-visited-file-name (format "/tmp/%s_%s_%s" buffer-name pid title))

Then, the previous snippet may be desired.

So you may ask: "why would you even want to designate a file, the text gets stored in the kill-ring anyway?". There could be multiple different reasons for that. The main one for me is the lsp-mode. The way how it works - it requires a buffer content to be bound to a file on disk, and it's a bit annoying when Emacs prompts you to save the file, even for small, insignificant edits.