### PR TITLE
Update bind.fnl error message + windows:undo

### DIFF
--- a/config.example.fnl
+++ b/config.example.fnl
@@ -241,7 +241,7 @@
           :action "windows:show-grid"}
          {:key :u
           :title "Undo"
-          :action "windows:undo-action"}]))
+          :action "windows:undo"}]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Apps Menu

--- a/lib/bind.fnl
+++ b/lib/bind.fnl
@@ -33,8 +33,10 @@
     (if f
         (f (table.unpack (or args [])))
         (do
-          (log.wf "Could not invoke action %s"
-                  action)))))
+          (log.wf "Could not dispatch action %s: Function \"%s\" was not found in module \"%s\".\nEnsure the correct action is referenced in config.fnl."
+                  action
+                  fn-name
+                  file)))))
 
 
 (fn create-action-fn


### PR DESCRIPTION
- Updates bind.fnl error message to be more useful when it can't resolve a string like `windows:undo-action` to a function
- Updates config.example.fnl to point to `windows:undo` instead of `windows:undo-action`

Fixes #127 