### PR TITLE
fix paste phase of edit-with-emacs

### DIFF
--- a/emacs.fnl
+++ b/emacs.fnl
@@ -104,7 +104,9 @@
   (let [app (hs.application.applicationForPID (tonumber pid))]
     (when app
       (: app :activate)
-      (: app :selectMenuItem [:Edit :Paste]))))
+      (hs.timer.doAfter
+       0.01
+       (fn [] (: app :selectMenuItem [:Edit :Paste]))))))
 
 (fn maximize
   []

--- a/emacs.fnl
+++ b/emacs.fnl
@@ -105,7 +105,7 @@
     (when app
       (: app :activate)
       (hs.timer.doAfter
-       0.01
+       0.001
        (fn [] (: app :selectMenuItem [:Edit :Paste]))))))
 
 (fn maximize


### PR DESCRIPTION
closes: #126 

It looks like Firefox Developer Edition doesn't allow an immediate access to the
menu after the app gets activated. Adding a tiny delay seems to be fixing the
issue.