### PR TITLE
Rework statemachine

### DIFF
--- a/lib/functional.fnl
+++ b/lib/functional.fnl
@@ -206,6 +206,14 @@
   (let [filtered (filter f tbl)]
     (<= 1 (length filtered))))
 
+(fn push
+  [tbl e]
+  (concat tbl [e]))
+
+(fn pop
+  [tbl]
+  (slice 1 -1 tbl))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Others
@@ -246,6 +254,8 @@
  : map
  : merge
  : noop
+ : pop
+ : push
  : reduce
  : seq
  : seq?

--- a/lib/functional.fnl
+++ b/lib/functional.fnl
@@ -206,12 +206,14 @@
   (let [filtered (filter f tbl)]
     (<= 1 (length filtered))))
 
-(fn push
+(fn conj
   [tbl e]
+  "Return a new list with the element e added at the end"
   (concat tbl [e]))
 
-(fn pop
+(fn butlast
   [tbl]
+  "Return a new list with all but the last item"
   (slice 1 -1 tbl))
 
 
@@ -234,9 +236,11 @@
 ;; Exports
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-{: call-when
+{: butlast
+ : call-when
  : compose
  : concat
+ : conj
  : contains?
  : count
  : eq?
@@ -254,8 +258,6 @@
  : map
  : merge
  : noop
- : pop
- : push
  : reduce
  : seq
  : seq?

--- a/lib/modal.fnl
+++ b/lib/modal.fnl
@@ -22,6 +22,8 @@ switching menus in one place which is then powered by config.fnl.
         : map
         : merge
         : noop
+        : push
+        : pop
         : slice}
        (require :lib.functional))
 (local {:align-columns align-columns}
@@ -272,7 +274,7 @@ switching menus in one place which is then powered by config.fnl.
    :stop-timeout :nil
    :unbind-keys (bind-menu-keys menu.items)
    :history (if history
-                (concat [] history [menu])
+                (push history menu)
                 [menu])})
 
 
@@ -438,7 +440,7 @@ switching menus in one place which is then powered by config.fnl.
                (show-modal-menu (merge state
                                        {:menu prev-menu
                                         :prev-menu menu}))
-               {:history (slice 1 -1 history)})
+               {:history (pop history)})
         (idle->active state))))
 
 

--- a/lib/modal.fnl
+++ b/lib/modal.fnl
@@ -12,8 +12,10 @@ switching menus in one place which is then powered by config.fnl.
 (local atom (require :lib.atom))
 (local statemachine (require :lib.statemachine))
 (local apps (require :lib.apps))
-(local {: call-when
+(local {: butlast
+        : call-when
         : concat
+        : conj
         : find
         : filter
         : has-some?
@@ -22,8 +24,6 @@ switching menus in one place which is then powered by config.fnl.
         : map
         : merge
         : noop
-        : push
-        : pop
         : slice}
        (require :lib.functional))
 (local {:align-columns align-columns}
@@ -274,7 +274,7 @@ switching menus in one place which is then powered by config.fnl.
    :stop-timeout :nil
    :unbind-keys (bind-menu-keys menu.items)
    :history (if history
-                (push history menu)
+                (conj history menu)
                 [menu])})
 
 
@@ -440,7 +440,7 @@ switching menus in one place which is then powered by config.fnl.
                (show-modal-menu (merge state
                                        {:menu prev-menu
                                         :prev-menu menu}))
-               {:history (pop history)})
+               {:history (butlast history)})
         (idle->active state))))
 
 

--- a/lib/new-statemachine.fnl
+++ b/lib/new-statemachine.fnl
@@ -1,7 +1,9 @@
 (local atom (require :lib.atom))
 (local {: butlast
+        : call-when
         : concat
         : conj
+        : last
         : merge
         : slice} (require :lib.functional))
 
@@ -10,21 +12,17 @@
 ;;
 ;; Schema
 ;; { :current-state ; An atom keyword
+;;   ; States table: A map of state names to a map of actions to functions
+;;   ; These functions must return a map containing the new state keyword, the
+;;   ; effect, and a new context
 ;;   :states {:state1 {}
 ;;            :state2 {}
-;;            :state3
-;;                     ; TODO: Do we want :enter and :exit, or let the effects
-;;                     ; callback handle it
-;;                     {:leave :state2
-;;                      :enter :state3}
-;;            :state4 {}
-;;                     }}}
+;;            :state3 {:leave :state2
+;;                     :enter :state3}}}}
 ;;   :transitions} ; takes in fsm & event
-;;   ; TODO: Could this :context be completely separate from the FSM? Since only
-;;   ; `effects` callbacks should touch it. How it is provided to them, though?'
 ;;   :context ; an atom that tracks extra data e.g. current app, history, etc.
 ;;
-(fn set-state
+(fn set-current-state
   [fsm state]
   (atom.swap! fsm.current-state (fn [_ state] state) state))
 
@@ -32,23 +30,25 @@
   [fsm action extra]
   "Based on the action and the fsm's current-state, set the new state and call
   the all subscribers with the old state, new state, action, and extra"
-  (log.wf "signal action :%s" action) ;; DELETEME
   (let [current-state (atom.deref fsm.current-state)
-        next-state ((. fsm.states current-state action) fsm.context action extra)
-        effect next-state.effect]
+        _ (log.wf "XXX Current state %s" current-state) ;; DELETEME
+        ; TODO: Better name? This is the map that contains old, new, effect, etc.
+        ; TODO: Handle a signal with no handler
+        transition ((. fsm.states current-state action) fsm.context action extra)
+        _ (log.wf "XXX received transition info %s" (hs.inspect transition)) ;; DELETEME
+        next-state transition.current-state
+        new-context transition.context
+        _ (log.wf "XXX next state %s" next-state) ;; DELETEME
+        effect transition.effect]
     ; If next-state is nil, error: Means the action is not expected in this state
-    (log.wf "XXX Signal current: :%s next: :%s action: :%s extra: %s effect: :%s" (atom.deref fsm.current-state) (hs.inspect next-state) action extra effect) ;; DELETEME
-    (if next-state
-        (do
-          (set-state fsm next-state)
+    (log.wf "XXX Signal current: :%s next: :%s action: :%s extra: %s effect: :%s" current-state next-state action extra effect) ;; DELETEME
+
+    (set-current-state fsm next-state)
           ; TODO: Should we let this callback decide on the new state? But there
           ; can be multiple listeners
           ; TODO: Provide whole FSM or just context?
-          (each [_ sub (pairs (atom.deref fsm.subscribers))]
-            (log.wf "Calling sub %s" sub) ;; DELETEME
-                (sub {:prev-state current-state :next-state next-state :effect effect}))
-          )
-        (log.wf "Action :%s is not defined in state :%s" action current-state))))
+    (each [_ sub (pairs (atom.deref fsm.subscribers))]
+      (sub {:context new-context :prev-state current-state :next-state next-state :effect effect :extra extra}))))
 
 (fn subscribe
   [fsm sub]
@@ -64,6 +64,27 @@
     (fn []
       (atom.swap! fsm.subscribers (fn [subs key] (tset subs key nil)) sub-key))))
 
+(fn effect-handler
+  [effect-map]
+  "
+  Takes a map of effect->function and returns a function that handles these
+  effects and cleans up on the next transition.
+
+  These functions must return their own cleanup function
+
+  Not required but cleans up some of the state management code
+  "
+  ;; Create a one-time atom used to store the cleanup function
+  (let [cleanup-ref (atom.new nil)]
+    ;; Return a subscriber function
+    (fn [{: context : prev-state : next-state : effect : action : extra}]
+      (log.wf "Effect handler called")
+      ;; Whenever a transition occurs, call the cleanup function, if set
+      (call-when (atom.deref cleanup-ref))
+      ;; Get a new cleanup function or nil and update cleanup-ref atom
+      (atom.reset! cleanup-ref
+                   (call-when (. effect-map effect) context extra)))))
+
 (fn create-machine
   [states initial-state]
   (merge {:current-state (atom.new initial-state)
@@ -77,81 +98,100 @@
 
 (var modal-fsm nil)
 (fn enter-menu
-  [context menu]
-  (log.wf "XXX Enter menu %s. Current stack: %s" menu (hs.inspect (atom.deref context.menu-stack))) ;; DELETEME
-  (atom.swap! context.menu-stack (fn [stack menu] (conj stack menu)) menu)
+  [context action extra]
+  (log.wf "XXX Enter menu action: %s. Current stack: %s" action (hs.inspect (atom.deref context.menu-stack))) ;; DELETEME
+  (atom.swap! context.menu-stack (fn [stack menu] (conj stack menu)) extra)
   {:current-state :menu
-   :context {:history []
-             :menu :main-menu}
+   :context (merge context {:menu-stack context.menu-stack
+                            :current-menu :main})
    :effect :modal-opened})
 
 (fn up-menu
-  [context menu]
-  "Go up a menu in the stack. If we are the last menu, then we must fire an
-  event to :leave"
+  [context action extra]
+  "Go up a menu in the stack."
   (log.wf "XXX Up menu. Current stack: %s" (hs.inspect (atom.deref context.menu-stack))) ;; DELETEME
-  ; TODO: Unbind keys from this menu
-  (let [stack (atom.deref (atom.swap! context.menu-stack (fn [stack] (butlast stack))))]
-    (when (= (length stack) 0) (signal modal-fsm :leave))))
+  ; Pop the menu off the stack
+  (atom.swap! context.menu-stack (fn [stack] (butlast stack)))
+  ; Calculate new state transition
+  (let [stack (atom.deref context.menu-stack)
+        depth (length stack)
+        target-state (if (= 0 depth) :idle :menu)
+        target-effect (if (= :idle target-state) :modal-closed :modal-opened)
+        new-menu (last stack)]
+    {:current-state target-state
+     :context (merge context {:menu-stack context.menu-stack
+                              :current-menu new-menu})
+     :effect target-effect}) )
 
 (fn leave-menu
-  [context]
-  (log.wf "XXX Leave menu") ;; DELETEME
+  [context action extra]
   (log.wf "XXX Leave menu. Current stack: %s" (hs.inspect (atom.deref context.menu-stack))) ;; DELETEME
-  ; TODO: Unbind keys from this menu
-  (atom.swap! context.menu-stack (fn [_ menu] []))
-  )
-
-(fn modal-action
-  ; 'extra' would be the key hit, or name of the action, so we know which
-  ; submenu to enter, for example. A menu with 4 options would bind each to a
-  ; function calling (signal :enter), but each with their own 'extra'. Maybe the
-  ; key hit or the menu itself
-  [context old-state new-state action extra]
-  (log.wf "XXX Got action :%s with extra %s while in :%s, transitioning to :%s" action extra old-state new-state) ;; DELETEME
-  (if (=  old-state :idle)
-      (if (= action :leave) nil
-          (= action :open) (enter-menu context :main))
-      (= old-state :menu)
-      (if (= action :leave) (leave-menu context)
-          (= action :back) (up-menu context extra)
-          ; TODO: Which menu? Does enter-menu figure it out or do we?
-          (= action :select) (enter-menu context extra))))
-
+  {:current-state :idle
+   :context {:menu-stack context.menu-stack
+             :menu :main-menu}
+   :effect :modal-closed})
 
 (local modal-states
        {:states {:idle {:leave :idle
-                        :open (fn [context action extra]
-                                {:current-state :menu
-                                 :context {:history []
-                                           :menu :main-menu}
-                                 :effect :modal-opened})}
+                        :open enter-menu}
                  :menu {:leave leave-menu
                         :back up-menu
                         :select enter-menu}}
-        :context {:modal {:modal nil
-                          :stop-func nil}
+        :context {
                   ; TODO: This would be filled based on config
-                  :menu-hierarchy nil
+                  :menu-hierarchy {:a {}
+                                   :b {}
+                                   :c {}}
+                  :current-menu nil
                   :menu-stack (atom.new [])}})
 
-; This creates an atom for current-state and context
-; TODO: We could require the initiali state me a key in the states map
+; TODO: We could require the initial state be a key in the states map
 ; TODO: If we preserve the initial context we can maybe fsm.reset, thoug that's
 ; hard to do safely since it only restores state and context, not the state of
 ; hammerspoon itself, e.g. keys bindings, that have been messed with with all
 ; the signal handlers.
-(set modal-fsm (create-machine modal-states :idle))
-(local unsub-display (subscribe modal-fsm (fn [] (alert "MENU HERE"))))
-(local unsub-bind (subscribe modal-fsm (fn [] (log.wf "Binding keys..."))))
-(log.wf "Subs: %s" (hs.inspect (atom.deref modal-fsm.subscribers))) ;; DELETEME
-;; (unsub) ;; DELETEME
-;; (log.wf "Subs: %s" (hs.inspect (atom.deref modal-fsm.subscribers))) ;; DELETEME
+(fn modal-opened-menu-handler
+  [context extra]
+  (log.wf "Modal opened menu handler called")
+  (alert (string.format "MENU %s" extra))
+  ;; Return a cleanup func
+  (fn [] (log.wf "Modal opened menu handler CLEANUP called")))
 
-; Debuging bindings
-(hs.hotkey.bind [:cmd] :s (fn [] (log.wf "XXX Current stack: %s" (hs.inspect (atom.deref modal-fsm.context.menu-stack))))) ;; DELETEME
+(fn modal-opened-key-handler
+  [context extra]
+  (log.wf "Modal opened key handler called")
+  ; TODO: Make this consider keys relative to its position in the hierarchy
+  (if (. context :menu-hierarchy extra)
+      (log.wf "Key in hierarchy")
+      (log.wf "Key NOT in hierarchy"))
+  ;; Return a cleanup func
+  (fn [] (log.wf "Modal opened key handler CLEANUP called")))
+
+; Create FSM
+(set modal-fsm (create-machine modal-states :idle))
+
+; Add subscribers
+(local unsub-menu-sub
+       (subscribe modal-fsm (effect-handler {:modal-opened modal-opened-menu-handler})))
+(local unsub-key-sub
+       (subscribe modal-fsm (effect-handler {:modal-opened modal-opened-key-handler})))
+(log.wf "Subs: %s" (hs.inspect (atom.deref modal-fsm.subscribers))) ;; DELETEME
+
+; Debuging bindings. Call it in config.fnl so it's not trampled
+(fn bind []
+  (hs.hotkey.bind [:alt :cmd :ctrl] :v
+                  (fn []
+                    (log.wf "XXX Current stack: %s"
+                            (hs.inspect (atom.deref modal-fsm.context.menu-stack)))))
+  (hs.hotkey.bind [:cmd] :o (fn [] (signal modal-fsm :open :main)))
+  (hs.hotkey.bind [:cmd] :u (fn [] (signal modal-fsm :back nil)))
+  (hs.hotkey.bind [:cmd] :l (fn [] (signal modal-fsm :leave nil)))
+  (hs.hotkey.bind [:cmd] :a (fn [] (signal modal-fsm :select :a)))
+  (hs.hotkey.bind [:cmd] :b (fn [] (signal modal-fsm :select :b)))
+  (hs.hotkey.bind [:cmd] :c (fn [] (signal modal-fsm :select :c))))
 
 {: signal
+ : bind
  : modal-fsm  ;; DELETEME
  : subscribe
  :new create-machine}

--- a/lib/new-statemachine.fnl
+++ b/lib/new-statemachine.fnl
@@ -1,0 +1,138 @@
+(local atom (require :lib.atom))
+(local {: merge
+        : concat
+        : push
+        : pop
+        : slice} (require :lib.functional))
+
+(local log (hs.logger.new "\tstatemachine.fnl\t" "debug"))
+
+;;
+;; Schema
+;; { :current-state ; An atom keyword
+;;   :states {:state1 {}
+;;            :state2 {}
+;;            :state3 {
+;;                     ; TODO: Do we want :enter and :exit, or let the effects
+;;                     ; callback handle it
+;;                     :transitions {:leave :state2
+;;                                   :enter :state3}
+;;            :state4 {}
+;;                     }}}
+;;   :transitions} ; takes in fsm & event
+;;   ; TODO: Could this :context be completely separate from the FSM? Since only
+;;   ; `effects` callbacks should touch it. How it is provided to them, though?'
+;;   :context ; an atom that tracks extra data e.g. current app, history, etc.
+;;
+(fn set-state
+  [fsm state]
+  (atom.swap! fsm.current-state (fn [_ state] state) state))
+
+(fn signal
+  [fsm action extra]
+  "Based on the action and the fsm's current-state, set the new state and call
+  the effects listener with the old state, new state, action, and extra"
+  (let [current-state (atom.deref fsm.current-state)
+        next-state (. fsm.states current-state :transitions action)
+        effects fsm.effects]
+    ; If next-state is nil, error: Means the action is not expected in this state
+    (log.wf "XXX Signal current: :%s next: :%s action: :%s extra: %s" (atom.deref fsm.current-state) next-state action extra) ;; DELETEME
+    (if next-state
+        (do
+          (set-state fsm next-state)
+          ; TODO: Should we let this callback decide on the new state? But there
+          ; can be multiple listeners
+          ; TODO: Provide whole FSM or just context?
+          (effects fsm.context current-state next-state action extra))
+        (log.wf "Action :%s is not defined in state :%s" action current-state))))
+
+(fn create-machine
+  [states initial-state]
+  (merge {:current-state (atom.new initial-state)
+          :context (atom.new states.context)}
+         states))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Example
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(var modal-fsm nil)
+(fn enter-menu
+  [context menu]
+  (log.wf "XXX Enter menu %s. Current stack: %s" menu (hs.inspect (atom.deref context.menu-stack))) ;; DELETEME
+  ; TODO: Show the actual menu
+  ; TODO: Bind keys according to actual menu
+  (alert "menu")
+  (atom.swap! context.menu-stack (fn [stack menu] (push stack menu)) menu)
+  (hs.hotkey.bind [:cmd] "l" (fn [] (signal modal-fsm :leave)))
+  ; Down a menu deeper
+  (hs.hotkey.bind [:cmd] "d"
+                  (fn [] (signal modal-fsm :select (tostring (length (atom.deref context.menu-stack))))))
+  ; Up a menu
+  (hs.hotkey.bind [:cmd] "u" (fn [] (signal modal-fsm :back))))
+
+(fn up-menu
+  [context menu]
+  "Go up a menu in the stack. If we are the last menu, then we must fire an
+  event to :leave"
+  (log.wf "XXX Up menu. Current stack: %s" (hs.inspect (atom.deref context.menu-stack))) ;; DELETEME
+  ; TODO: Unbind keys from this menu
+  (let [stack (atom.deref (atom.swap! context.menu-stack (fn [stack] (pop stack))))]
+    (when (= (length stack) 0) (signal modal-fsm :leave))))
+
+(fn leave-menu
+  [context]
+  (log.wf "XXX Leave menu") ;; DELETEME
+  (log.wf "XXX Leave menu. Current stack: %s" (hs.inspect (atom.deref context.menu-stack))) ;; DELETEME
+  ; TODO: Unbind keys from this menu
+  (atom.swap! context.menu-stack (fn [_ menu] []))
+  )
+
+(fn modal-action
+  ; 'extra' would be the key hit, or name of the action, so we know which
+  ; submenu to enter, for example. A menu with 4 options would bind each to a
+  ; function calling (signal :enter), but each with their own 'extra'. Maybe the
+  ; key hit or the menu itself
+  [context old-state new-state action extra]
+  (log.wf "XXX Got action :%s with extra %s while in :%s, transitioning to :%s" action extra old-state new-state) ;; DELETEME
+  (if (=  old-state :idle)
+      (if (= action :leave) nil
+          (= action :activate) (enter-menu context :main))
+      (= old-state :menu)
+      (if (= action :leave) (leave-menu context)
+          (= action :back) (up-menu context extra)
+          ; TODO: Which menu? Does enter-menu figure it out or do we?
+          (= action :select) (enter-menu context extra))))
+
+
+(local modal-states
+       {:states {:idle {:enter nil
+                        :exit nil
+                        :transitions {:leave :idle
+                                      :activate :menu}}
+                 :menu {:enter nil
+                        :exit nil
+                        ; TODO: How can we allow a transition to a previous menu
+                        :transitions {
+                                      ; Leave dumps all menus
+                                      :leave :idle
+                                      ; Back pops a menu off the stack
+                                      :back :menu
+                                      ; Select pushes a menu on the stack
+                                      :select :menu}}}
+        ; TODO: This would be an event stream dispatcher or publish func
+        :effects modal-action
+        :context {:modal {:modal nil
+                          :stop-func nil}
+                  ; TODO: This would be filled based on config
+                  :menu-hierarchy nil
+                  :menu-stack (atom.new [])}})
+
+; This creates an atom for current-state and context
+(set modal-fsm (create-machine modal-states :idle))
+
+; Debuging bindings
+(hs.hotkey.bind [:cmd] :s (fn [] (log.wf "XXX Current stack: %s" (hs.inspect (atom.deref modal-fsm.context.menu-stack))))) ;; DELETEME
+
+{: signal
+ :modal-fsm modal-fsm  ;; DELETEME
+ :new create-machine}

--- a/lib/new-statemachine.fnl
+++ b/lib/new-statemachine.fnl
@@ -1,8 +1,8 @@
 (local atom (require :lib.atom))
-(local {: merge
+(local {: butlast
         : concat
-        : push
-        : pop
+        : conj
+        : merge
         : slice} (require :lib.functional))
 
 (local log (hs.logger.new "\tstatemachine.fnl\t" "debug"))
@@ -62,7 +62,7 @@
   ; TODO: Show the actual menu
   ; TODO: Bind keys according to actual menu
   (alert "menu")
-  (atom.swap! context.menu-stack (fn [stack menu] (push stack menu)) menu)
+  (atom.swap! context.menu-stack (fn [stack menu] (conj stack menu)) menu)
   (hs.hotkey.bind [:cmd] "l" (fn [] (signal modal-fsm :leave)))
   ; Down a menu deeper
   (hs.hotkey.bind [:cmd] "d"
@@ -76,7 +76,7 @@
   event to :leave"
   (log.wf "XXX Up menu. Current stack: %s" (hs.inspect (atom.deref context.menu-stack))) ;; DELETEME
   ; TODO: Unbind keys from this menu
-  (let [stack (atom.deref (atom.swap! context.menu-stack (fn [stack] (pop stack))))]
+  (let [stack (atom.deref (atom.swap! context.menu-stack (fn [stack] (butlast stack))))]
     (when (= (length stack) 0) (signal modal-fsm :leave))))
 
 (fn leave-menu


### PR DESCRIPTION
WIP.

This reworks the statemachine as imagined by @eccentric-j.

It keeps the state machine static, only uses 2 atoms: 1 for current state and one for context.

Each _state_ defines a function for each _action_ it supports. These functions return a new state, a new context, and an _effect_. Effects are sent to all subscribers, along with the new state and new context. They cannot modify the state or context, but can instead use it. The intent here is to allow these 'effect handlers' to display modals, set up hot keys, etc.

Additionally, we add a helper `effect-handler`, which is a higher order function that takes a map of effect->handler, and closes over an atom. The handlers provided in this way should return their own cleanup function, which is stored in the atom. This allows the returned function to be registered as an effect handler and to have the returned cleanup function automatically called on the subsequent event.