### PR TITLE
emacs: Fix modal import

### DIFF
--- a/emacs.fnl
+++ b/emacs.fnl
@@ -116,7 +116,7 @@
    (fn []
      (let [app     (hs.application.find :Emacs)
            windows (require :windows)
-           modal   (require :modal)]
+           modal   (require :lib.modal)]
        (when app
          (: app :activate)
          (windows.maximize-window-frame))))))


### PR DESCRIPTION
This must have been broken for months.

In testing something else I noticed the import error.