### PR TITLE
fixes jump-window

### DIFF
--- a/windows.fnl
+++ b/windows.fnl
@@ -162,9 +162,8 @@
   Returns nil
   "
   (let [dir {:h "West" :j "South" :k "North" :l "East"}
-        space (. (hs.window.focusedWindow) :filter :defaultCurrentSpace)
         fn-name (.. :focusWindow (. dir arrow))]
-    (: space fn-name nil true true)
+    (: (hs.window.focusedWindow) fn-name nil true true)
     (highlight-active-window)))
 
 (fn jump-window-left


### PR DESCRIPTION
Bug discovered while testing #149. Upstream. Looks like it's broken in Hammerspoon. Removed usage of the experimental module.

https://github.com/agzam/spacehammer/pull/149#issuecomment-961617007