### PR TITLE
windows: Add resize-to-grid

### DIFF
--- a/windows.fnl
+++ b/windows.fnl
@@ -212,8 +212,8 @@
 (fn grid
   [method direction]
   "
-  Moves, expands, or shrinks a the active window by the next grid dimension
-  Grid settings are specified in config.fnl.
+  Moves, expands, or shrinks the active window by the next grid dimension. Grid
+  settings are specified in config.fnl.
   "
   (let [fn-name (.. method direction)
         f (. hs.grid fn-name)]
@@ -340,6 +340,14 @@
   []
   (resize-window :l))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Resize to grid preset
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(fn resize-to-grid
+  [grid]
+  (: history :push)
+  (hs.grid.set (hs.window.focusedWindow) grid))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Move to screen directions
@@ -551,6 +559,7 @@
  : resize-left
  : resize-right
  : resize-up
+ : resize-to-grid
  : set-mouse-cursor-at
  : show-display-numbers
  : show-grid


### PR DESCRIPTION
I use a bunch of mapping that move the active window to a preset grid (see [here](https://github.com/Grazfather/dotfiles/blob/e95082093c3ff67dfdbfd1d7b42b0170a42a29ef/spacehammer/config.fnl#L239)). In #155 I discovered the `undo` functionality, and would like to use it.

This PR simply adds a function that allows someone to resize a window to a specified grid, but pushes the dimensions onto the history stack so that undo works for it.