### PR TITLE
Only support fennel >= v1.0.0

### DIFF
--- a/README.ORG
+++ b/README.ORG
@@ -23,12 +23,14 @@
     #+begin_src bash
       brew cask install hammerspoon
     #+end_src
-*** Install Fennel
+*** Install Fennel >= v1.0.0
     #+begin_src bash
       brew install luarocks
 
       luarocks install fennel
     #+end_src
+
+    Older versions of Fennel are incompatible with Spacehammer.
 *** Clone Spacehammer
     #+begin_src bash
       git clone https://github.com/agzam/spacehammer ~/.hammerspoon

--- a/repl.fnl
+++ b/repl.fnl
@@ -1,7 +1,6 @@
 (local coroutine (require :coroutine))
 (local fennel (require :fennel))
 (local jeejah (require :jeejah))
-(local view (require :fennelview))
 (local {:merge merge} (require :lib.functional))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Maybe we don't want this, but we can't nicely support both < 1 and >= 1 because fennel v1.0.0 incorporates `fennelview` into its std.

Actually, according to the [release notes](https://fennel-lang.org/v0.8.0/) it's been that way since v0.8.0.

Most people might not use `repl`, but I don't like that anyone who wants to try it out will be treated to an error. My preference is to simply set a requirement on the minimum fennel version.