### PR TITLE
Update doc strings for consistency

### DIFF
--- a/lib/apps.fnl
+++ b/lib/apps.fnl
@@ -37,7 +37,7 @@ This module works mechanically similar to lib/modal.fnl.
 (fn gen-key
   []
   "
-  Generate a unique, random, base64 encoded string 7 chars long.
+  Generates a unique, random, base64 encoded string 7 chars long.
   Takes no arguments.
   Side effectful.
   Returns unique 7 char, randomized string.
@@ -50,8 +50,7 @@ This module works mechanically similar to lib/modal.fnl.
 (fn emit
   [action data]
   "
-  When an action occurs in our state machine we want to broadcast it for systems
-  like modals to transition.
+  Broadcasts an action from our state machine so modals can transition.
   Takes action name and data to transition another finite state machine.
   Side-effect: Updates the actions atom.
   Returns nil.
@@ -77,7 +76,7 @@ This module works mechanically similar to lib/modal.fnl.
 (fn leave
   [app-name]
   "
-  The user has deactivated\blurred an app we have config defined.
+  The user has deactivated/blurred an app we have config defined.
   Takes the name of the app the user deactivated.
   Transition the state machine to idle from active app state.
   Returns nil.
@@ -112,7 +111,7 @@ This module works mechanically similar to lib/modal.fnl.
 (fn bind-app-keys
   [items]
   "
-  Bind config.fnl app keys  to actions
+  Binds config.fnl app keys to actions
   Takes a list of local app bindings
   Returns a function to call without arguments to remove bindings.
   "
@@ -143,7 +142,7 @@ This module works mechanically similar to lib/modal.fnl.
 (fn ->enter
   [state action app-name]
   "
-  Transition the app state machine from the general, shared key bindings to an
+  Transitions the app state machine from the general, shared key bindings to an
   app we have local keybindings for.
   Kicks off an effect to bind app-specific keys.
   Takes the current app state machine state table
@@ -162,7 +161,7 @@ This module works mechanically similar to lib/modal.fnl.
 (fn in-app->leave
   [state action app-name]
   "
-  Transition the app state machine from an app the user was using with local
+  Transitions the app state machine from an app the user was using with local
   keybindings to another app that may or may not have local keybindings.
   Because a 'enter (new) app' action is fired before a 'leave (old) app', we
   know that this will be called AFTER the enter transition has updated the
@@ -343,8 +342,8 @@ Assign some simple keywords for each hs.application.watcher event type.
 (fn enter-app-effect
   [context]
   "
-  Bind keys and lifecycle for the new current app.
-  Return a cleanup function to cleanup these bindings.
+  Binds keys and lifecycle for the new current app.
+  Returns a cleanup function to cleanup these bindings.
   "
   (when context.app
     (lifecycle.activate-app context.app)
@@ -355,8 +354,8 @@ Assign some simple keywords for each hs.application.watcher event type.
 (fn launch-app-effect
   [context]
   "
-  Bind keys and lifecycle for the next current app.
-  Return a cleanup function to cleanup these bindings.
+  Binds keys and lifecycle for the next current app.
+  Returns a cleanup function to cleanup these bindings.
   "
   (when context.app
     (lifecycle.launch-app context.app)

--- a/lib/atom.fnl
+++ b/lib/atom.fnl
@@ -34,7 +34,7 @@ Example:
 (fn atom
   [initial]
   "
-  Create an atom instance
+  Creates an atom instance
   Takes an initial value
   Returns atom table instance
 

--- a/lib/functional.fnl
+++ b/lib/functional.fnl
@@ -28,7 +28,9 @@
 
 (fn find
   [f tbl]
-  "Execute a function across a table and return the first element where that function returns true."
+  "Executes a function across a table and return the first element where that
+  function returns true.
+  "
   (fu.find tbl f))
 
 (fn get
@@ -105,7 +107,7 @@
 
 (fn split
   [separator str]
-  "Using specified separator, convert string to an array of strings."
+  "Converts string to an array of strings using specified separator."
   (fu.split str separator))
 
 (fn tap

--- a/lib/text.fnl
+++ b/lib/text.fnl
@@ -10,7 +10,7 @@ action are all vertically aligned based on the longest value of each column.
 (fn max-length
   [items]
   "
-  Finds the max length of each  value in a column
+  Finds the max length of each value in a column
   Takes a list of key value pair lists
   Returns the maximum length in characters.
   "
@@ -38,10 +38,10 @@ action are all vertically aligned based on the longest value of each column.
 (fn align-columns
   [items]
   "
-  Align the key column of the menu items by padding out each
+  Aligns the key column of the menu items by padding out each
   key string with a space to match the longest item key string.
   Takes a list of modal menu items
-  Returns a list of veritcally aligned row strings
+  Returns a list of vertically aligned row strings
   "
   (let [max (max-length items)]
     (map


### PR DESCRIPTION
Just updated some docs for consistency.

We tend to use singular present tense over imperative, e.g. "Does this" rather than "Do this".

Also fix some wording, formatting, and typos.