### PR TITLE
Fix windows.center-window-frame

### DIFF
--- a/windows.fnl
+++ b/windows.fnl
@@ -109,7 +109,7 @@
   (let [win (hs.window.focusedWindow)
         prev-duration hs.window.animationDuration
         config (get-config)
-        ratio  (or config.modules.windows.center-ratio "80:50")
+        ratio  (or (?. config :modules :windows :center-ratio) "80:50")
         screen (hs.screen.primaryScreen)]
     (tset hs.window :animationDuration 0)
     (position-window-center ratio win screen)


### PR DESCRIPTION
This function was broken if the user didn't have the windows module set in his config.