### PR TITLE
remove needless coroutine

### DIFF
--- a/emacs.fnl
+++ b/emacs.fnl
@@ -30,15 +30,13 @@
                      (emacsclient-exe)
                      " -e '(spacehammer-edit-with-emacs "
                      pid " " title " " screen " )' &")
-        co          (coroutine.create (fn [run-str]
-                                        (io.popen run-str)))
         prev        (hs.pasteboard.changeCount)
         _           (hs.eventtap.keyStroke [:cmd] :c)
         next        (hs.pasteboard.changeCount)]
     (when (= prev next)         ; Pasteboard was not updated so no text was selected
       (hs.eventtap.keyStroke [:cmd] :a)  ; select all and then copy
       (hs.eventtap.keyStroke [:cmd] :c))
-    (coroutine.resume co run-str)
+    (io.popen run-str)
     (hs.application.open :Emacs)))
 
 (fn run-emacs-fn


### PR DESCRIPTION
Fixes: #186 

According the git-blame the couroutine was added to alleviate (perhaps some imaginary problems), back in the day when "edit-with-emacs" was using a separate frame. I think the garbage collector in some cases fails to clean it up. I'm still not completely sure if that's the exact thing that's causing #186, but after removing the coroutine and testing for a couple of days, I'm no longer experiencing the issues described in #186