### PR TITLE
bugfix: window jumps

### DIFF
--- a/windows.fnl
+++ b/windows.fnl
@@ -161,9 +161,9 @@
   Returns nil
   "
   (let [dir {:h "West" :j "South" :k "North" :l "East"}
-        space (. (hs.window.focusedWindow) :filter :defaultCurrentSpace)
-        fn-name (.. :focusWindow (. dir arrow))]
-    (: space fn-name nil true true)
+        frontmost-win (hs.window.frontmostWindow)
+        focus-dir (.. :focusWindow (. dir arrow))]
+    (: hs.window.filter.defaultCurrentSpace focus-dir frontmost-win true true)
     (highlight-active-window)))
 
 (fn jump-window-left


### PR DESCRIPTION
Alternative to #150  - I noticed jumps weren't working, and went and fixed it before noticing the open PR! This continues using the filter, so will only jump to windows on the current space.

`jump-window` was trying to access a nonexistent `:filter` property of windows instead of `hs.window.filter`. Corrected to instead call `(: hs.window.filter :focusWindow<Dir> <frontmost-window> true true)`.

One minor change from the original is the use of `(hs.window.frontmostWindow)` as the reference window in place of `(hs.window.focusedWindow)`; this will normally use the focused window, but if no window has focus, falls back to the one on "top."

~~Note: Another option would be to use [`(hs.window.filter:focus<Dir>)`](https://www.hammerspoon.org/docs/hs.window.filter.html#focusEast), which calls `hs.window.focusWindowDir(nil, nil, true)`, nearly identical to what's here except it will include windows covered (or partially covered) by others in the current space/filter when picking which window to focus.~~

~~I erred on the side of sticking with the originally-intended behavior, but I did play around with it the other way, and I wasn't entirely sure which I liked better. Still, thought I'd mention it for consideration. Might be nice if that's configurable, but I may be over-complicating things.~~

**EDIT:** I tried it with the `hs.window.filter.focus<Dir>` approach and, yeah, when you have a number of layered windows, it's *way* too annoying 😆