### PR TITLE
Adjustable log levels

### DIFF
--- a/core.fnl
+++ b/core.fnl
@@ -9,6 +9,7 @@
         :reduce    reduce
         :split     split
         :some      some} (require :lib.functional))
+(local {: logger} (require :lib.utils))
 (local atom (require :lib.atom))
 (require-macros :lib.macros)
 (require-macros :lib.advice.macros)
@@ -24,7 +25,7 @@
 (local customdir (.. homedir "/.spacehammer"))
 (tset fennel :path (.. customdir "/?.fnl;" fennel.path))
 
-(local log (hs.logger.new "\tcore.fnl\t" "debug"))
+(local log (logger "\tcore.fnl\t" "debug"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; defaults
@@ -236,3 +237,6 @@ Returns nil. This function causes side-effects.
                       {path (module.init config)})))
              (reduce #(merge $1 $2) {})))
 
+;; override log level for named loggers in config
+(each [logger-id level (pairs (or config.log-levels {}))]
+  (logger logger-id level))

--- a/lib/apps.fnl
+++ b/lib/apps.fnl
@@ -20,9 +20,10 @@ This module works mechanically similar to lib/modal.fnl.
         :bind-keys bind-keys}
        (require :lib.bind))
 (local lifecycle (require :lib.lifecycle))
+(local {: logger} (require :lib.utils))
 
 
-(local log (hs.logger.new "apps.fnl" "debug"))
+(local log (logger "apps.fnl" "debug"))
 
 (local actions (atom.new nil))
 ;; Create a dynamic var to hold an accessible instance of our finite state

--- a/lib/bind.fnl
+++ b/lib/bind.fnl
@@ -3,8 +3,9 @@
         : map
         : split}
        (require :lib.functional))
+(local {: logger} (require :lib.utils))
 
-(local log (hs.logger.new "bind.fnl" "debug"))
+(local log (logger "bind.fnl" "debug"))
 
 (fn do-action
   [action args]

--- a/lib/lifecycle.fnl
+++ b/lib/lifecycle.fnl
@@ -1,5 +1,6 @@
 (local {: do-action} (require :lib.bind))
-(local log (hs.logger.new "lifecycle.fnl" "debug"))
+(local {: logger} (require :lib.utils))
+(local log (logger "lifecycle.fnl" "debug"))
 
 
 "

--- a/lib/modal.fnl
+++ b/lib/modal.fnl
@@ -24,6 +24,7 @@ switching menus in one place which is then powered by config.fnl.
         : map
         : merge}
        (require :lib.functional))
+(local {: logger} (require :lib.utils))
 (local {:align-columns align-columns}
        (require :lib.text))
 (local {:action->fn action->fn
@@ -31,7 +32,7 @@ switching menus in one place which is then powered by config.fnl.
        (require :lib.bind))
 (local lifecycle (require :lib.lifecycle))
 
-(local log (hs.logger.new "modal.fnl" "debug"))
+(local log (logger "modal.fnl" "debug"))
 (var fsm nil)
 (local default-style {:textFont "Menlo"
                       :textSize 16

--- a/lib/statemachine.fnl
+++ b/lib/statemachine.fnl
@@ -47,7 +47,7 @@ the next transition.
         : last
         : merge
         : slice} (require :lib.functional))
-
+(local {: logger} (require :lib.utils))
 
 (fn update-state
   [fsm state]
@@ -124,7 +124,7 @@ the next transition.
   (let [fsm  {:state (atom.new {:current-state template.state.current-state :context template.state.context})
               :states template.states
               :subscribers (atom.new {})
-              :log (if template.log (hs.logger.new template.log "info"))}]
+              :log (if template.log (logger template.log "info"))}]
     ; Add methods
     (tset fsm :get-state (partial get-state fsm))
     (tset fsm :send (partial send fsm))

--- a/lib/utils.fnl
+++ b/lib/utils.fnl
@@ -1,3 +1,5 @@
+(local fennel (require :fennel))
+
 (fn global-filter
   []
   "
@@ -6,4 +8,20 @@
   (let [filter (hs.window.filter.new)]
     (: filter :setAppFilter :Emacs {:allowRoles [:AXUnknown :AXStandardWindow :AXDialog :AXSystemDialog]})))
 
-{:global-filter global-filter}
+(fn get-or-add-logger [loggers id ?level]
+  "If (. loggers id) exists, returns it; otherwise instaniates & stores a new one.
+If ?level is provided, sets it on the new or existing hs.logger instance.
+`loggers` is expected to be a weak-valued table."
+  (case (. loggers id)
+    log (do (when ?level (log.setLogLevel ?level))
+            log)
+    _ (let [log (hs.logger.new id ?level)]
+        (tset loggers id log)
+        log)))
+
+;; Weak-valued table to store instantiated loggers by ID. Can be called as a
+;; function to create & store a new instance, optioanlly with provided log level
+(local logger (setmetatable {} {:__mode :v :__call get-or-add-logger}))
+
+{:global-filter global-filter
+ : logger}

--- a/vim.fnl
+++ b/vim.fnl
@@ -9,9 +9,11 @@
         : map
         : noop
         : some} (require :lib.functional))
+(local {: logger} (require :lib.utils))
+
 (local statemachine (require :lib.statemachine))
 (local {:bind-keys bind-keys} (require :lib.bind))
-(local log (hs.logger.new "vim.fnl" "debug"))
+(local log (logger "vim.fnl" "debug"))
 
 "
 Create a vim mode for any text editor!


### PR DESCRIPTION
This one's kind of out of left field, but since I already implemented it locally and find it pretty useful when debugging my spacehammer code without distractions, I figured I'd submit a PR and see if it was something you'd find potentially worth merging 😉. No harm if you close this in the event I'm the only one who finds it useful! Also, let me know if the impl + config field/format looks good or if you'd prefer something different. Thanks!

## Usecase

There are times I've found troubleshooting things I do with my config a little unwieldy due to the log noise generated by the `modal.fnl`/`apps.fnl` debug logs. Since hammerspoon doesn't do anything special with the logger ID's in terms of managing id -> instance centrally, making each namespaced logger configurable would have required either exporting them each from their relevant modules or storing them in a container.

To simplify things, wrote a small state container for any instantiated loggers in `lib/utils.fnl`; just a weak-valued table for storing logger instances by ID and a function that either fetches an existing logger by name or instantiates and stores a new one, setting log level if provided.

I then proceeded to add support for a `log-levels` field in config, which is iterated at startup in `core.fnl` to override log levels:

```fennel
;; disables debug output for modal/app focus change
(set config.log-levels {:apps.fnl :info :modal.fnl :info})
```