### PR TITLE
Fix error on first use with non-default config dir

### DIFF
--- a/core.fnl
+++ b/core.fnl
@@ -100,7 +100,7 @@ Returns nil. This function causes side-effects.
 ;; If ~/.spacehammer/config.fnl does not exist
 ;; - Create ~/.spacehammer dir
 ;; - Copy default ~/.hammerspoon/config.example.fnl to ~/.spacehammer/config.fnl
-(let [example-path (.. homedir "/.hammerspoon/config.example.fnl")
+(let [example-path (.. hs.configdir "/config.example.fnl")
       target-path (.. customdir "/config.fnl")]
   (when (not (file-exists? target-path))
     (log.d (.. "Copying " example-path " to " target-path))


### PR DESCRIPTION
```
% defaults write org.hammerspoon.Hammerspoon MJConfigFile "~/.config/hammerspoon/init.lua"
```

The above allows changing the path to init.lua from the default `~/.hammerspoon` and this tiny change avoids an error in such cases.