### PR TITLE
functional: Re-implement reduce using accumulate

### DIFF
--- a/lib/functional.fnl
+++ b/lib/functional.fnl
@@ -141,10 +141,9 @@
 
 (fn reduce
   [f acc tbl]
-  (var result acc)
-  (each [k v (seq tbl)]
-    (set result (f result v k)))
-  result)
+  (accumulate [acc acc
+               k v (seq tbl)]
+    (f acc v k)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/functional-test.fnl
+++ b/test/functional-test.fnl
@@ -42,4 +42,9 @@
         (fn []
           (is.eq? (f.some #(> $1 3) [1 2 3 4 5 6]) true "some did not find that table has elements greater than 3")
           (is.eq? (f.some #(> $1 3) [1 2 3]) false "some incorrectly found that table has elements greater than 3")))
+
+    (it "reduce applies a function to each k v of a sequence, accumulating an returning an end result"
+        (fn []
+          (is.eq? (f.reduce #(.. $1 $2) "" [5 4 3 2 1]) "54321" "reduce did not concat list into string")
+          (is.eq? (f.reduce #(if (> $1 $3) $1 $3) 0 [1 3 5 2 0]) 5 "reduce did not find max")))
     ))


### PR DESCRIPTION
I just noticed that fennel added `accumulate` in v0.10. We can probably replace many `reduce` calls with it directly, but reduce is still nice.

This change reimplements `reduce` to use `accumulate`, and adds some tests.