### PR TITLE
windows.fnl: fix resize-{up,down}

### DIFF
--- a/windows.fnl
+++ b/windows.fnl
@@ -329,11 +329,11 @@
 
 (fn resize-up
   []
-  (resize-window :j))
+  (resize-window :k))
 
 (fn resize-down
   []
-  (resize-window :k))
+  (resize-window :j))
 
 (fn resize-right
   []


### PR DESCRIPTION
It looks like the :j / :k assignment has been flipped in `windows.fnl`:

in `config.example.fnl`, :j = "resize-down" and :k = "resize-up"
```
(local window-resize
       [...
        {:mods [:shift]
         :key :j
         :action "windows:resize-down"
         :repeatable true}
        {:mods [:shift]
         :key :k
         :action "windows:resize-up"
         :repeatable true}
        ...])
```

But this is the reverse (before this PR) in `windows.fnl`:
```
(fn resize-up
  []
  (resize-window :j))

(fn resize-down
  []
  (resize-window :k))
```