### PR TITLE
fix: app switching error

### DIFF
--- a/lib/apps.fnl
+++ b/lib/apps.fnl
@@ -347,9 +347,11 @@ Assign some simple keywords for each hs.application.watcher event type.
   "
   (when context.app
     (lifecycle.activate-app context.app)
-    (let [unbind-keys (bind-app-keys context.app.keys)]
+    (let [unbind-keys (when context.app.keys
+                        (bind-app-keys context.app.keys))]
       (fn []
-        (unbind-keys)))))
+        (when unbind-keys
+          (unbind-keys))))))
 
 (fn launch-app-effect
   [context]
@@ -359,9 +361,11 @@ Assign some simple keywords for each hs.application.watcher event type.
   "
   (when context.app
     (lifecycle.launch-app context.app)
-    (let [unbind-keys (bind-app-keys context.app.keys)]
+    (let [unbind-keys (when context.app.keys
+                        (bind-app-keys context.app.keys))]
       (fn []
-        (unbind-keys)))))
+        (when unbind-keys
+          (unbind-keys))))))
 
 (fn app-effect-handler
   [effect-map]

--- a/lib/bind.fnl
+++ b/lib/bind.fnl
@@ -69,7 +69,7 @@
   Returns a function to remove bindings.
   "
   (let [modal (hs.hotkey.modal.new [] nil)]
-    (each [_ item (ipairs items)]
+    (each [_ item (ipairs (or items []))]
       (let [{:key key
              :mods mods
              :action action


### PR DESCRIPTION
it would sometimes throw:

```
2025-12-18 16:31:16: 16:31:16 ERROR:   LuaSkin: hs.application.watcher callback: attempt to index a nil value
stack traceback:
	[C]: in for iterator 'for iterator'
	./lib/bind.fnl:42: in function 'lib.bind.bind-keys'
	(...tail calls...)
	./lib/apps.fnl:126: in function <./lib/apps.fnl:123>
	(...tail calls...)
	./lib/apps.fnl:158: in local 'sub'
	./lib/statemachine.fnl:43: in function 'lib.statemachine.send'
	(...tail calls...)
```

The app watcher would crash with "attempt to index a nil value" when switching to apps that have lifecycle
methods (`:activate`, `:launch`, etc.) defined in config but no `:keys` field. The code attempted to bind keybindings for all configured apps, but didn't check if the `:keys` field existed before passing it to `bind-keys`.

Adding basic nil checks fixes it