### PR TITLE
Clobber fewer emacs movements in default keybinds

### DIFF
--- a/config.example.fnl
+++ b/config.example.fnl
@@ -425,20 +425,28 @@
                {:mods [:ctrl]
                 :key :t
                 :action "slack:thread"}
-               {:mods [:ctrl]
-                :key :p
-                :action "slack:prev-day"}
-               {:mods [:ctrl]
-                :key :n
-                :action "slack:next-day"}
-               {:mods [:ctrl]
-                :key :e
-                :action "slack:scroll-up"
-                :repeat true}
-               {:mods [:ctrl]
-                :key :y
-                :action "slack:scroll-down"
-                :repeat true}
+               ;; {:mods [:ctrl]
+               ;;  :key :p
+               ;;  :action "slack:prev-day"}
+               ;; {:mods [:ctrl]
+               ;;  :key :n
+               ;;  :action "slack:next-day"}
+               ;; {:mods [:ctrl]
+               ;;  :key :e
+               ;;  :action "slack:scroll-up"
+               ;;  :repeat true}
+               ;; {:mods [:ctrl]
+               ;;  :key :y
+               ;;  :action "slack:scroll-down"
+               ;;  :repeat true}
+               ;; {:mods [:ctrl]
+               ;;  :key :k
+               ;;  :action "slack:up"
+               ;;  :repeat true}
+               ;; {:mods [:ctrl]
+               ;;  :key :j
+               ;;  :action "slack:down"
+               ;;  :repeat true}
                {:mods [:ctrl]
                 :key :i
                 :action "slack:next-history"
@@ -446,14 +454,6 @@
                {:mods [:ctrl]
                 :key :o
                 :action "slack:prev-history"
-                :repeat true}
-               {:mods [:ctrl]
-                :key :j
-                :action "slack:down"
-                :repeat true}
-               {:mods [:ctrl]
-                :key :k
-                :action "slack:up"
                 :repeat true}]})
 
 (local apps


### PR DESCRIPTION
I found a couple of the default keybindings to be fairly significant disruptions to my macOS and emacs text editing muscle memory. While I love vim-style normal mode bindings, I also use `evil-disable-insert-state-bindings` (i.e. vanilla emacs is my insert mode) and heavily use macOS's global support for basic emacs/readline-style movement and editing commands in all text fields.

This PR changes the example config to avoid these disruptions; existing installations will be unaffected (although it's true that existing users who don't track their config with e.g. a dotfiles repo may be surprised by the changes the next time they install spacehammer on a new computer).

There were two major "culprits" of this workflow disruption:
- `M-n` and `M-p` are globally bound, rendering common extended navigation commands unavailable in emacs (e.g. `magit-section-forward-sibling`, or `previous-history-element` in the minibuffer). This PR updates the default bindings to use `:cmd :alt` instead of just `:alt`; they are adjacent keys, so it shouldn't be a drastic difference in ergonomics.
- The slack bindings clobber `C-e`, `C-k`, `C-n`, and `C-p`, all of which I heavily use when writing messages in slack. To make things worse, I had some focus issues such that `C-e` was scrolling the current slack channel instead of moving my cursor to the EOL _even with a different app focused_*. I didn't see an obvious or intuitive alternative to the existing vim-based keybinding scheme, so this PR comments out all pairs of slack bindings that clobber one or more of those key bindings (pun only sort of intended); it is perhaps a suboptimal fix, but they're documented in the example config itself and trivial to reenable.

Thoughts?

\* This last bit may be an unrelated bug (and possibly a macOS and/or hammerspoon bug, given the bumpy rollout of Tahoe), but even without it, shadowing such a useful and (for me) commonly-used binding is disruptive enough even just within Slack.