### PR TITLE
Improves edit-with-emacs feature

### DIFF
--- a/CHANGELOG.ORG
+++ b/CHANGELOG.ORG
@@ -1,3 +1,20 @@
+* [2026-03-03 Mon]
+** 2.0.0 - Edit-with-Emacs v2
+*** Session-based architecture
+Each edit invocation creates a unique session, enabling multiple simultaneous edit buffers across different apps.
+*** Direct text injection via macOS Accessibility API
+Text fields with settable AXValue are written to directly - no clipboard clobbering, no app switching (for supported apps). Falls back to clipboard-based Cmd+V for apps without AX support.
+*** Selection-aware editing
+Selecting a portion of text before invoking edit-with-emacs opens a buffer with only the selected text. On sync/finish, only the selected portion is replaced (prefix/suffix anchoring), and the replaced range is re-selected in the target app via AXSelectedTextRange.
+*** Live sync (C-c C-s)
+Push text changes to the target app without closing the edit buffer. Enables iterative editing with visual feedback.
+*** Clipboard safety net
+Text always passes through the system clipboard (even in AX mode), so clipboard history managers can always recover it.
+*** Informative header-line
+Edit buffers display the caller app name, [selection] indicator, and keybindings for submit/sync/cancel.
+*** Comprehensive feature spec
+Added =docs/edit-with-emacs-spec.org= documenting architecture, invariants, IPC interface, and manual test matrix.
+
 * [2026-01-07 Wed]
 ** 1.6.1 - fix emacsclient location detection
 

--- a/docs/edit-with-emacs-spec.org
+++ b/docs/edit-with-emacs-spec.org
@@ -1,0 +1,354 @@
+#+TITLE: Edit-with-Emacs — Feature Specification
+#+STARTUP: showall
+
+* Overview
+
+Edit-with-Emacs (EWE) lets you edit any text field in any macOS app using
+Emacs. It is a *two-process system*:
+
+- *Hammerspoon side* (~emacs.fnl~, Fennel/Lua): captures text, manages
+  sessions, writes text back to the target app.
+- *Emacs side* (~spacehammer.el~, Elisp): provides the editing buffer, minor
+  mode, keybindings, and IPC calls back to Hammerspoon.
+
+Communication flows in both directions:
+- Hammerspoon → Emacs: via ~emacsclient -e~ (evaluates elisp)
+- Emacs → Hammerspoon: via ~hs -c~ CLI (evaluates Lua/Fennel)
+
+* Architecture
+
+** Write-back modes
+
+Every session operates in one of two modes, chosen at session creation:
+
+| Mode       | Condition                             | Read text via | Write text via          |
+|------------+---------------------------------------+---------------+-------------------------|
+| =:ax=        | Focused element is a recognized text  | Clipboard     | AXUIElement setAXValue  |
+|            | role AND AXValue is settable          | (Cmd+C)       | (direct, no app switch) |
+|------------+---------------------------------------+---------------+-------------------------|
+| =:clipboard= | AX element unavailable or unsupported | Clipboard     | Clipboard + Cmd+V       |
+|            |                                       | (Cmd+C)       | (requires app switch)   |
+
+AX element detection checks for these roles: =AXTextArea=, =AXTextField=,
+=AXComboBox=, =AXTextView=. The element must also report ~isAttributeSettable
+:AXValue~ as true.
+
+** Session state
+
+Each invocation creates a session (stored in the ~sessions~ table, keyed by
+session-id). A session contains:
+
+| Field         | Description                                             |
+|---------------+---------------------------------------------------------|
+| =pid=           | Process ID of the originating app                       |
+| =title=         | Window title of the originating app                     |
+| =screen=        | Display ID where the invocation happened                |
+| =ax-element=    | Stored AXUIElement reference (nil in clipboard mode)    |
+| =mode=          | =:ax= or =:clipboard=                                       |
+| =has-selection= | Boolean — true if user had text selected at invocation  |
+| =prefix=        | Text before the selection (nil if no selection / no AX) |
+| =suffix=        | Text after the selection (nil if no selection / no AX)  |
+| =original=      | The original text that was copied (from clipboard)      |
+
+** Selection-aware editing
+
+When the user selects a portion of text before invoking EWE:
+
+1. *Read*: Cmd+C copies just the selection. The Emacs buffer contains only the
+   selected text.
+2. *Anchoring*: ~build-session~ uses ~string.find~ to locate the selected text
+   within the full AXValue, splitting it into prefix and suffix.
+3. *Write-back*: ~session-write-ax~ reconstructs: ~prefix .. edited_text ..
+   suffix~, then writes the full string via AXValue.
+4. *Re-selection*: After a 100ms delay (apps reset AXSelectedTextRange when
+   AXValue changes), sets AXSelectedTextRange to
+   ~{:location (length prefix) :length (length edited_text)}~.
+
+This means subsequent syncs continue to replace only the selected portion.
+
+*Known limitation*: prefix/suffix anchoring uses ~string.find~ with plain match.
+If the selected text appears multiple times in the field, it will anchor to the
+*first* occurrence. Using AXSelectedTextRange at capture time would be more
+reliable but is not yet implemented.
+
+* Lifecycle
+
+** 1. Invocation (~edit-with-emacs~)
+
+Triggered by a global hotkey (default: Cmd+Ctrl+O).
+
+#+begin_example
+User presses hotkey
+    │
+    ├─ Capture: current window, app PID, title, screen ID
+    ├─ Probe: get-focused-text-element (AX check)
+    ├─ Generate: unique session-id
+    ├─ Send: Cmd+C (copy)
+    │
+    ├─ wait-for-clipboard-change (poll up to 500ms)
+    │   │
+    │   ├─ Clipboard changed? → User had a selection
+    │   │   └─ build-session(... had-selection=true)
+    │   │
+    │   └─ No change? → Nothing was selected
+    │       ├─ Send: Cmd+A, Cmd+C (select all, copy)
+    │       ├─ wait-for-clipboard-change again
+    │       │   ├─ Changed? → build-session(... had-selection=false)
+    │       │   └─ Still nothing? → Last resort: read AXValue directly
+    │       │       └─ Set clipboard from AXValue, build-session(... had-selection=false)
+#+end_example
+
+** 2. Buffer creation (~spacehammer-edit-with-emacs~, Emacs side)
+
+Called by Hammerspoon via emacsclient.
+
+1. Create/reuse buffer named =* spacehammer-edit TITLE [SESSION-ID] *=
+2. Set buffer-local variables: pid, title, session-id, selection-only
+3. ~clipboard-yank~ — paste text from system clipboard into buffer
+4. Enable ~spacehammer-edit-with-emacs-mode~ (minor mode)
+5. ~pop-to-buffer~ — display the buffer
+6. Run ~spacehammer-edit-with-emacs-hook~ (user customization point)
+7. Set header-line (after hooks, so major-mode changes don't clobber it)
+
+** 3a. Sync (~C-c C-s~ → ~spacehammer-sync-edit-with-emacs~)
+
+Pushes buffer text to the originating app *without* closing the buffer.
+
+#+begin_example
+Emacs                                    Hammerspoon
+  │                                          │
+  ├─ Get buffer text                         │
+  ├─ Escape for Lua string                   │
+  ├─ hs -c syncText(session-id, text) ──────►│
+  │                                          ├─ AX mode?
+  │                                          │   ├─ session-write-ax (write prefix+text+suffix)
+  │                                          │   ├─ After 100ms: set AXSelectedTextRange
+  │                                          │   └─ Set clipboard (safety net)
+  │                                          │
+  │                                          └─ Clipboard mode?
+  │                                              ├─ Selection: paste-via-clipboard, return to Emacs
+  │                                              └─ No selection: Cmd+A, Cmd+V, return to Emacs
+  │                                          │
+  ├─ Show "Synced" message                   │
+  └─ Run spacehammer-after-sync-hook         │
+#+end_example
+
+** 3b. Finish (~C-c C-c~ → ~spacehammer-finish-edit-with-emacs~)
+
+Pushes buffer text and *ends* the session.
+
+1. Run ~spacehammer-before-finish-edit-with-emacs-hook~
+2. Kill buffer (or buffer+window if not sole window)
+3. IPC: ~finishSession(session-id, text)~
+   - AX mode: write via AX, set clipboard (safety), re-select, activate app
+   - Clipboard mode: ~paste-via-clipboard~
+4. Session removed from sessions table
+
+Legacy fallback (no session-id): uses ~clipboard-kill-ring-save~ +
+~switchToAppAndPasteFromClipboard~.
+
+** 3c. Cancel (~C-c C-k~ → ~spacehammer-cancel-edit-with-emacs~)
+
+Abandons edits, returns to originating app.
+
+1. Run ~spacehammer-before-cancel-edit-with-emacs-hook~
+2. Kill buffer (or buffer+window)
+3. IPC: ~cancelSession(session-id)~ — activates app, removes session
+
+No text is written back.
+
+* Invariants
+
+These must always hold. Violating any of them is a regression.
+
+** Clipboard safety net
+Every text transition must leave a trace in the system clipboard:
+- *On read*: Text is always copied to the clipboard via Cmd+C (or set
+  explicitly via ~hs.pasteboard.setContents~ as a last resort).
+- *On write (sync/finish)*: ~hs.pasteboard.setContents text~ is called even
+  in AX mode. This ensures clipboard history managers always have a copy.
+
+** Buffer-local variables survive major-mode changes
+~spacehammer--caller-pid~, ~spacehammer--session-id~,
+~spacehammer--selection-only~, ~spacehammer--caller-title~ all have
+~permanent-local~ property set. Hooks that change major mode (e.g., activating
+~markdown-mode~) must not lose session state.
+
+** Selection-only edits preserve surrounding text
+When ~has-selection~ is true and prefix/suffix are set, write-back must
+reconstruct ~prefix + edited_text + suffix~. The buffer only ever contains the
+selected portion — never the full field.
+
+** Selection re-adjustment after write-back
+After setting AXValue in selection mode, AXSelectedTextRange must be set (with
+a 100ms delay) to ~{:location (length prefix) :length (length edited_text)}~.
+This keeps the replaced portion visually selected in the target app, enabling
+repeated sync cycles.
+
+** Session cleanup
+~finish-session~ and ~cancel-session~ must always remove the session from the
+sessions table, even if the write-back fails.
+
+** AX element re-acquisition
+~session-write-ax~ must attempt to re-acquire the AX element via
+~ax-get-app-element~ if the stored reference is nil (element went stale). The
+re-acquired reference must be stored back in the session.
+
+** Header-line set after hooks
+~spacehammer--set-header-line~ is called after
+~spacehammer-edit-with-emacs-hook~ runs, because hook functions commonly change
+the major mode (which resets ~header-line-format~).
+
+** Emacs window cleanup
+Buffer kill uses ~kill-buffer-and-window~ when the edit buffer is not the sole
+window, ~kill-buffer~ otherwise. This avoids leaving empty windows.
+
+* Emacs-side extension points
+
+| Hook                                           | When                   | Args                    |
+|------------------------------------------------+------------------------+-------------------------|
+| ~spacehammer-edit-with-emacs-hook~               | Buffer created & shown | buffer-name, pid, title |
+| ~spacehammer-before-finish-edit-with-emacs-hook~ | Before buffer killed   | buffer-name, pid        |
+| ~spacehammer-before-cancel-edit-with-emacs-hook~ | Before buffer killed   | buffer-name, pid        |
+| ~spacehammer-after-sync-hook~                    | After sync IPC sent    | buffer-name, session-id |
+
+Typical hook usage: switch major mode based on app title, set visited-file-name
+for LSP, enter insert state (Evil/Vim).
+
+* Keybindings (spacehammer-edit-with-emacs-mode)
+
+| Key     | Command                            | Action                      |
+|---------+------------------------------------+-----------------------------|
+| ~C-c C-c~ | ~spacehammer-finish-edit-with-emacs~ | Submit text, close buffer   |
+| ~C-c C-s~ | ~spacehammer-sync-edit-with-emacs~   | Push text, keep buffer open |
+| ~C-c C-k~ | ~spacehammer-cancel-edit-with-emacs~ | Abandon, close buffer       |
+
+* IPC interface
+
+** Hammerspoon → Emacs (via emacsclient -e)
+
+| Elisp function              | Args                                           |
+|-----------------------------+------------------------------------------------|
+| ~spacehammer-edit-with-emacs~ | pid, title, screen, session-id, selection-only |
+
+** Emacs → Hammerspoon (via hs -c)
+
+| Lua expression (via require("emacs"))  | Purpose                          |
+|----------------------------------------+----------------------------------|
+| ~.syncText(session-id, text)~            | Push text without ending session |
+| ~.finishSession(session-id, text)~       | Push text and end session        |
+| ~.cancelSession(session-id)~             | End session without writing      |
+| ~.getSessionInfo(session-id)~            | Query session metadata           |
+| ~.switchToApp(pid)~                      | Legacy: activate app by PID      |
+| ~.switchToAppAndPasteFromClipboard(pid)~ | Legacy: activate + Edit>Paste    |
+
+* String escaping chain
+
+Text passes through multiple escaping layers:
+
+1. *Lua side* (~escape-elisp-string~): escapes ~\~, ~"~, ~\n~, ~\r~ for
+   embedding in elisp string literals sent via emacsclient.
+2. *Elisp side* (~spacehammer--escape-lua-string~): escapes ~\~, ~"~, ~\n~,
+   ~\r~ for embedding in Lua string literals sent via ~hs -c~.
+
+This is a fragile area. Any text containing unusual characters (backslashes,
+quotes, control characters, unicode) must survive the round-trip without
+corruption.
+
+* Known limitations
+
+1. *Prefix/suffix anchoring uses string.find*: If the selected text appears
+   multiple times in the field, it anchors to the first occurrence. Could be
+   fixed by using AXSelectedTextRange at capture time instead.
+
+2. *Clipboard mode sync is disruptive*: In clipboard fallback mode, sync
+   requires switching to the target app, pasting, and switching back. The user
+   sees a brief app flash.
+
+3. *AX element staleness*: Stored AXUIElement references can go stale if the
+   target app's UI changes (e.g., navigating to a different view). Re-acquisition
+   via ~ax-get-app-element~ helps but depends on the same field being focused.
+
+4. *100ms delay for selection re-adjustment*: Apps reset AXSelectedTextRange
+   when AXValue changes. The 100ms timer is empirically chosen; some slow apps
+   might need more.
+
+5. *Cmd+C race*: ~wait-for-clipboard-change~ polls at 50ms intervals for up to
+   500ms. Extremely slow apps may not respond in time.
+
+6. *No multi-cursor/multi-selection support*: Only a single contiguous
+   selection is supported.
+
+* Customization example: direction-aware buffer placement
+
+The edit buffer can be displayed on the side of the Emacs frame closest to the
+caller app. This is a personal customization (not part of spacehammer.el) since
+it only applies to GUI Emacs.
+
+The approach: a custom ~display-buffer~ action function reads
+~spacehammer--caller-pid~ from the buffer (already set before ~pop-to-buffer~),
+queries Hammerspoon for the caller app's window center via ~hs -c~, compares
+with ~(frame-position)~ + ~(frame-pixel-width)~, and passes the direction to
+~display-buffer-in-quadrant~.
+
+~do-applescript~ (Emacs built-in) is used rather than ~hs -c~ or ~osascript~
+because it runs in-process with zero subprocess overhead. Requires Emacs to
+have Accessibility permission in macOS Privacy & Security settings. If the
+permission is stale (e.g., after an Emacs upgrade), remove and re-add Emacs,
+then restart it — macOS caches permission denials per-process.
+
+* Manual test matrix
+
+Use this after changes to verify nothing is broken.
+
+** Scenario 1: Full-field edit, AX mode app (e.g., Slack, Notes)
+1. Focus a text field with some text, no selection
+2. Press Cmd+Ctrl+O
+3. *Expect*: Emacs buffer opens with full text, header shows app name, no "[selection]"
+4. Edit text, press C-c C-c
+5. *Expect*: Buffer closes, target app activates, text is replaced
+6. *Expect*: Clipboard contains the edited text
+
+** Scenario 2: Selection-only edit, AX mode app
+1. Select a portion of text in a text field
+2. Press Cmd+Ctrl+O
+3. *Expect*: Emacs buffer contains only the selected text, header shows "[selection]"
+4. Edit text, press C-c C-s (sync)
+5. *Expect*: Target app text updates — only the selected portion is replaced, surrounding text intact
+6. *Expect*: The replaced portion is visually selected in the target app
+7. Edit again, press C-c C-s again
+8. *Expect*: Same behavior — only the (now changed) portion is replaced again
+9. Press C-c C-c (finish)
+10. *Expect*: Buffer closes, target app activates, final text in place
+
+** Scenario 3: Cancel
+1. Start an edit session (either full or selection)
+2. Make some changes in the buffer
+3. Press C-c C-k
+4. *Expect*: Buffer closes, target app activates, original text unchanged
+
+** Scenario 4: Clipboard fallback (e.g., app where AX is not available)
+1. Focus a text field in an app that doesn't expose AX text elements
+2. Press Cmd+Ctrl+O
+3. *Expect*: Emacs buffer opens with text
+4. Edit and C-c C-c
+5. *Expect*: App activates, text is pasted via clipboard
+
+** Scenario 5: Clipboard safety
+1. Perform any edit session (AX or clipboard mode)
+2. After finish or sync, check clipboard history manager
+3. *Expect*: The edited text appears in clipboard history
+
+** Scenario 6: Hook-driven major mode change
+1. Configure ~spacehammer-edit-with-emacs-hook~ to activate a major mode
+   (e.g., ~markdown-mode~)
+2. Start an edit session
+3. *Expect*: Major mode is active, header-line is visible, C-c C-c/C-s/C-k all work
+4. *Expect*: Buffer-local session variables (pid, session-id) survived the mode change
+
+** Scenario 7: Multiple simultaneous sessions
+1. Start an edit session from App A — don't finish it
+2. Switch to App B, start another edit session
+3. *Expect*: Both buffers exist with distinct names and session IDs
+4. Finish each independently
+5. *Expect*: Each writes back to its own originating app

--- a/emacs.fnl
+++ b/emacs.fnl
@@ -1,3 +1,63 @@
+(local ax (require :hs.axuielement))
+(local log (hs.logger.new "ewe" "info"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Sessions - each edit-with-emacs invocation creates a session
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(var sessions {})
+(var session-counter 0)
+
+(fn gen-session-id []
+  (set session-counter (+ session-counter 1))
+  (.. "ewe-" session-counter "-" (math.floor (* (hs.timer.absoluteTime) 0.000001))))
+
+(fn get-focused-text-element []
+  "Get the currently focused UI element via Accessibility API.
+   Returns the element if it's a text-editable field with settable AXValue,
+   nil otherwise (triggers clipboard fallback)."
+  (let [sys (ax.systemWideElement)
+        el  (sys:attributeValue :AXFocusedUIElement)]
+    (when el
+      (let [role     (el:attributeValue :AXRole)
+            settable (el:isAttributeSettable :AXValue)]
+        ;; only return elements that are text-like AND have a settable value
+        (when (and settable
+                   (or (= role :AXTextArea)
+                       (= role :AXTextField)
+                       (= role :AXComboBox)
+                       (= role :AXTextView)))
+          el)))))
+
+(fn ax-set-value [el text]
+  "Set the AXValue on an element. Returns true on success."
+  (let [settable (el:isAttributeSettable :AXValue)]
+    (when settable
+      (el:setAttributeValue :AXValue text)
+      true)))
+
+(fn ax-get-app-element [pid]
+  "Get the focused text element for an app by PID. Used to re-acquire
+   a fresh AX reference in case the original one went stale."
+  (let [app (hs.application.applicationForPID (tonumber pid))]
+    (when app
+      (let [ax-app (ax.applicationElement app)
+            el     (ax-app:attributeValue :AXFocusedUIElement)]
+        (when (and el (el:isAttributeSettable :AXValue))
+          el)))))
+
+(fn escape-elisp-string [s]
+  "Escape a string for embedding in an elisp string literal."
+  (-> s
+      (: :gsub "\\\\" "\\\\\\\\")
+      (: :gsub "\"" "\\\\\"")
+      (: :gsub "\n" "\\\\n")
+      (: :gsub "\r" "\\\\r")))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Emacsclient helpers
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (fn emacsclient-exe []
   "Locate emacsclient executable."
   (let [(output status) (hs.execute "export PATH=$PATH:/opt/homebrew/bin && which emacsclient")
@@ -8,6 +68,21 @@
             hs.application.find
             (: :path)
             (: :gsub "Emacs.app" "bin/emacsclient")))))
+
+(fn run-emacs-fn
+  [elisp-fn args]
+  "Executes given elisp function in emacsclient. If args table present, passes
+   them into the function."
+  (let [args-lst (when args (.. " '" (table.concat args " '")))
+        run-str  (.. (emacsclient-exe)
+                     " -e \"(funcall '" elisp-fn
+                     (if args-lst args-lst " &")
+                     ")\" &")]
+    (io.popen run-str)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Org Capture
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (fn capture [is-note]
   "Activates org-capture"
@@ -23,36 +98,245 @@
         timer       (hs.timer.delayed.new .1 (fn [] (io.popen run-str)))]
     (timer:start)))
 
-(fn edit-with-emacs []
-  "Executes emacsclient, evaluating a special elisp function in spacehammer.el
-   (it must be pre-loaded), passing PID, title and display-id of the caller."
-  (let [current-app (: (hs.window.focusedWindow) :application)
-        pid         (.. "\"" (current-app:pid) "\"")
-        title       (.. "\"" (current-app:title) "\"")
-        screen      (.. "\"" (: (hs.screen.mainScreen) :id) "\"")
-        run-str     (..
-                     (emacsclient-exe)
-                     " -e '(spacehammer-edit-with-emacs "
-                     pid " " title " " screen " )' &")
-        prev        (hs.pasteboard.changeCount)
-        _           (hs.eventtap.keyStroke [:cmd] :c)
-        next        (hs.pasteboard.changeCount)]
-    (when (= prev next)         ; Pasteboard was not updated so no text was selected
-      (hs.eventtap.keyStroke [:cmd] :a)  ; select all and then copy
-      (hs.eventtap.keyStroke [:cmd] :c))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Edit with Emacs - AX-powered version
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(fn wait-for-clipboard-change [prev-count callback retries]
+  "Poll clipboard until changeCount differs from prev-count, then call callback
+   with true. If retries exhausted (default 10, i.e. ~500ms), call with false."
+  (let [max-retries (or retries 10)
+        check (fn check [n]
+                (if (not= (hs.pasteboard.changeCount) prev-count)
+                    (callback true)
+                    (> n max-retries)
+                    (callback false)
+                    ;; else: try again in 50ms
+                    (hs.timer.doAfter 0.05 (fn [] (check (+ n 1))))))]
+    (check 1)))
+
+(fn open-emacs-for-session [session-id session had-selection]
+  "Open emacsclient for an edit session. Called after clipboard is ready."
+  (let [run-str (..
+                 (emacsclient-exe)
+                 " -e '(spacehammer-edit-with-emacs "
+                 "\"" session.pid "\" "
+                 "\"" (escape-elisp-string session.title) "\" "
+                 "\"" session.screen "\" "
+                 "\"" session-id "\" "
+                 (if had-selection "t" "nil")
+                 " )' &")]
     (io.popen run-str)
     (hs.application.open :Emacs)))
 
-(fn run-emacs-fn
-  [elisp-fn args]
-  "Executes given elisp function in emacsclient. If args table present, passes
-   them into the function."
-  (let [args-lst (when args (.. " '" (table.concat args " '")))
-        run-str  (.. (emacsclient-exe)
-                     " -e \"(funcall '" elisp-fn
-                     (if args-lst args-lst " &")
-                     ")\" &")]
-    (io.popen run-str)))
+(fn build-session [session-id pid title screen-id ax-el had-selection]
+  "Read clipboard and AX state, create session entry, open Emacs."
+  (log.i (.. "build-session: " session-id " sel=" (tostring had-selection)
+             " ax=" (tostring (not= nil ax-el))))
+  (let [selected-text (hs.pasteboard.getContents)
+        full-text     (when ax-el (ax-el:attributeValue :AXValue))
+        ;; For selection mode with AX: find prefix/suffix anchors
+        prefix        (when (and had-selection full-text selected-text)
+                        (let [pos (string.find full-text selected-text 1 true)]
+                          (when pos
+                            (full-text:sub 1 (- pos 1)))))
+        suffix        (when (and had-selection full-text selected-text prefix)
+                        (let [end-pos (+ (length prefix) (length selected-text))]
+                          (full-text:sub (+ end-pos 1))))
+        mode          (if ax-el :ax :clipboard)
+        session       {:pid           pid
+                       :title         title
+                       :screen        screen-id
+                       :ax-element    ax-el
+                       :mode          mode
+                       :has-selection had-selection
+                       :prefix        prefix
+                       :suffix        suffix
+                       :original      selected-text}]
+    (log.i (.. "session " session-id ": mode=" mode
+               " text-len=" (tostring (and selected-text (length selected-text)))))
+    (tset sessions session-id session)
+    (open-emacs-for-session session-id session had-selection)))
+
+(fn edit-with-emacs []
+  "Start an edit-with-emacs session.
+   Uses Cmd+C to grab text, then captures AX element for direct write-back.
+   Async: waits for clipboard to actually change before proceeding."
+  (let [current-win (hs.window.focusedWindow)
+        current-app (current-win:application)
+        pid         (current-app:pid)
+        title       (current-app:title)
+        screen-id   (tostring (: (hs.screen.mainScreen) :id))
+        session-id  (gen-session-id)
+        ax-el       (get-focused-text-element)
+        prev-count  (hs.pasteboard.changeCount)]
+    ;; Send Cmd+C and wait for clipboard to change
+    (hs.eventtap.keyStroke [:cmd] :c)
+    (wait-for-clipboard-change prev-count
+      (fn [got-selection]
+        (if got-selection
+            ;; User had text selected - Cmd+C worked
+            (build-session session-id pid title screen-id ax-el true)
+            ;; Nothing was selected - grab everything with Cmd+A, Cmd+C
+            (let [prev2 (hs.pasteboard.changeCount)]
+              (hs.eventtap.keyStroke [:cmd] :a)
+              (hs.eventtap.keyStroke [:cmd] :c)
+              (wait-for-clipboard-change prev2
+                (fn [got-all]
+                  (if got-all
+                      (build-session session-id pid title screen-id ax-el false)
+                      ;; Last resort: maybe AX has the text directly
+                      (let [ax-text (when ax-el (ax-el:attributeValue :AXValue))]
+                        (when ax-text
+                          (hs.pasteboard.setContents ax-text))
+                        (build-session session-id pid title screen-id ax-el false)))))))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; IPC functions - callable from Emacs via `hs -c`
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(fn paste-via-clipboard [text pid opts]
+  "Put text on clipboard, activate app, paste it.
+   opts.then-fn is called after paste completes."
+  (let [then-fn (. (or opts {}) :then-fn)]
+    (hs.pasteboard.setContents text)
+    (let [app (hs.application.applicationForPID (tonumber pid))]
+      (when app
+        (app:activate)
+        (hs.timer.doAfter 0.05
+          (fn []
+            (hs.eventtap.keyStroke [:cmd] :v)
+            (when then-fn
+              (hs.timer.doAfter 0.05 then-fn)))))))
+  "ok")
+
+(fn session-write-ax [session text]
+  "Write text back via AX for a session. For selection sessions, reconstructs
+   full value from prefix + edited text + suffix. Re-acquires a fresh AX
+   element if the stored one went stale. Returns true on success."
+  (let [;; try stored element first, re-acquire if stale
+        el (or session.ax-element (ax-get-app-element session.pid))]
+    (log.i (.. "write-ax: el=" (tostring (not= nil el))
+               " sel=" (tostring session.has-selection)))
+    (when el
+      ;; update stored ref in case we re-acquired
+      (tset session :ax-element el)
+      (let [sel? (and session.has-selection session.prefix session.suffix)
+            result (if sel?
+                       (ax-set-value el (.. session.prefix text session.suffix))
+                       (ax-set-value el text))]
+        (log.i (.. "write-ax result: " (tostring result)))
+        ;; Re-select the replaced portion so the user can see what changed.
+        ;; Delay is needed: apps reset AXSelectedTextRange when AXValue changes.
+        (when (and result sel?)
+          (hs.timer.doAfter 0.1
+            (fn []
+              (el:setAttributeValue :AXSelectedTextRange
+                {:location (length session.prefix) :length (length text)}))))
+        result))))
+
+(fn sync-text [session-id text]
+  "Push text from Emacs back to the originating app's text field without
+   ending the session. Callable from Emacs.
+
+   AX mode: write directly via accessibility (no app switch needed).
+   Clipboard mode: switch to app, paste, switch back."
+  (let [session (. sessions session-id)]
+    (when session
+      (if (= session.mode :ax)
+          (do
+            (session-write-ax session text)
+            ;; Always keep clipboard history as a safety net
+            (hs.pasteboard.setContents text)
+            "ok")
+          ;; clipboard fallback
+          (if session.has-selection
+              ;; paste over preserved visual selection, then return to Emacs
+              (do
+                (paste-via-clipboard text session.pid
+                  {:then-fn (fn [] (hs.application.open :Emacs))})
+                "ok")
+              ;; no selection: select all, paste, return to Emacs
+              (do
+                (hs.pasteboard.setContents text)
+                (let [app (hs.application.applicationForPID (tonumber session.pid))]
+                  (when app
+                    (app:activate)
+                    (hs.timer.doAfter 0.05
+                      (fn []
+                        (hs.eventtap.keyStroke [:cmd] :a)
+                        (hs.timer.doAfter 0.02
+                          (fn []
+                            (hs.eventtap.keyStroke [:cmd] :v)
+                            (hs.timer.doAfter 0.1
+                              (fn [] (hs.application.open :Emacs)))))))))
+                "ok"))))))
+
+(fn finish-session [session-id text]
+  "Finish editing: write final text to originating app and end session.
+   Callable from Emacs.
+
+   AX mode: write directly, then activate the app.
+   Clipboard mode: paste via clipboard."
+  (let [session (. sessions session-id)]
+    (when session
+      (if (= session.mode :ax)
+          (do
+            (session-write-ax session text)
+            ;; Always keep clipboard history as a safety net
+            (hs.pasteboard.setContents text)
+            (let [app (hs.application.applicationForPID (tonumber session.pid))]
+              (when app (app:activate))))
+          ;; clipboard fallback
+          (paste-via-clipboard text session.pid {}))
+      ;; clean up session
+      (tset sessions session-id nil)
+      "ok")))
+
+(fn cancel-session [session-id]
+  "Cancel editing: switch back to originating app without modifying text.
+   Callable from Emacs."
+  (let [session (. sessions session-id)]
+    (when session
+      (let [app (hs.application.applicationForPID (tonumber session.pid))]
+        (when app (app:activate)))
+      (tset sessions session-id nil)
+      "ok")))
+
+(fn get-session-info [session-id]
+  "Return session metadata as a string for Emacs. Callable from Emacs."
+  (let [session (. sessions session-id)]
+    (if session
+        (.. "{:mode \"" session.mode "\""
+            " :pid \"" (tostring session.pid) "\""
+            " :title \"" (escape-elisp-string session.title) "\""
+            " :has-selection " (if session.has-selection "true" "false")
+            "}")
+        "nil")))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Legacy IPC (keep for backward compat)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(fn switch-to-app [pid]
+  "Don't remove! - this is callable from Emacs See: `spacehammer/switch-to-app`
+   in spacehammer.el "
+  (let [app (hs.application.applicationForPID (tonumber pid))]
+    (when app (app:activate))))
+
+(fn switch-to-app-and-paste-from-clipboard [pid]
+  "Don't remove! - this is callable from Emacs See:
+   `spacehammer/finish-edit-with-emacs` in spacehammer.el."
+  (let [app (hs.application.applicationForPID (tonumber pid))]
+    (when app
+      (app:activate)
+      (hs.timer.doAfter
+       0.001
+       (fn [] (app:selectMenuItem [:Edit :Paste]))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Emacs window management
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (fn full-screen
   []
@@ -89,22 +373,6 @@
              (hs.application.launchOrFocus :Emacs)
              (windows.rect rect-left)))))))
 
-(fn switch-to-app [pid]
-  "Don't remove! - this is callable from Emacs See: `spacehammer/switch-to-app`
-   in spacehammer.el "
-  (let [app (hs.application.applicationForPID (tonumber pid))]
-    (when app (app:activate))))
-
-(fn switch-to-app-and-paste-from-clipboard [pid]
-  "Don't remove! - this is callable from Emacs See:
-   `spacehammer/finish-edit-with-emacs` in spacehammer.el."
-  (let [app (hs.application.applicationForPID (tonumber pid))]
-    (when app
-      (app:activate)
-      (hs.timer.doAfter
-       0.001
-       (fn [] (app:selectMenuItem [:Edit :Paste]))))))
-
 (fn maximize
   []
   "Maximizes Emacs GUI window after a short delay."
@@ -125,4 +393,9 @@
  :switchToApp                      switch-to-app
  :switchToAppAndPasteFromClipboard switch-to-app-and-paste-from-clipboard
  :vertical-split-with-emacs        vertical-split-with-emacs
- :run-emacs-fn                     run-emacs-fn}
+ :run-emacs-fn                     run-emacs-fn
+ ;; New session-based IPC
+ :syncText                         sync-text
+ :finishSession                    finish-session
+ :cancelSession                    cancel-session
+ :getSessionInfo                   get-session-info}

--- a/spacehammer.el
+++ b/spacehammer.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Maintainer: Ag Ibragimov <agzam.ibragimov@gmail.com>
-;; Version: 1.0.0
+;; Version: 2.0.0
 ;; Keywords: extensions tools
 ;; Homepage: https://github.com/agzam/spacehammer
 ;; Package-Requires: ((emacs "27"))
@@ -13,41 +13,96 @@
 ;;
 ;;; Commentary:
 ;;
-;; A few elisp helpers for Spacehammer
+;; Elisp helpers for Spacehammer's edit-with-emacs feature.
+;; v2: Session-based architecture with AXUIElement support.
+;;
+;; Features:
+;;   - Multiple simultaneous edit sessions (one per app/text field)
+;;   - Direct text injection via macOS Accessibility API (no clipboard clobbering)
+;;   - Selection-aware editing (edit just the selected text)
+;;   - Live sync: push text to the app without ending the session (C-c C-s)
+;;   - Fallback to clipboard-based approach when AX is unavailable
 ;;
 ;;; Code:
 
 (require 'cl-seq)
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Hammerspoon IPC
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun spacehammer--hs-cmd (lua-expr &optional async)
+  "Execute LUA-EXPR via the Hammerspoon IPC CLI.
+If ASYNC is non-nil, run asynchronously (fire-and-forget)."
+  (unless (executable-find "hs")
+    (user-error "Hammerspoon IPC command line (hs) not found"))
+  (if async
+      (call-process (executable-find "hs") nil 0 nil "-c" lua-expr)
+    (with-temp-buffer
+      (call-process (executable-find "hs") nil t nil "-c" lua-expr)
+      (string-trim (buffer-string)))))
+
 (defun spacehammer-switch-to-app (pid)
   "Switch to app with the given PID."
-  (unless (executable-find "hs")
-    (user-error "Hammerspoon IPC command line (hs) not found."))
   (when (and pid (eq system-type 'darwin))
-    (call-process (executable-find "hs") nil 0 nil "-c"
-                  (concat "require(\"emacs\").switchToApp (\"" pid "\")"))))
+    (spacehammer--hs-cmd
+     (format "require(\"emacs\").switchToApp(\"%s\")" pid)
+     t)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Buffer-local session variables
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defvar-local spacehammer--caller-pid nil
+  "PID of the app that invoked this edit buffer.")
+
+(defvar-local spacehammer--session-id nil
+  "Unique session ID linking this buffer to a Hammerspoon session.")
+
+(defvar-local spacehammer--selection-only nil
+  "Non-nil if this buffer edits only the selected text, not the whole field.")
+
+(defvar-local spacehammer--caller-title nil
+  "Title of the app window that invoked this edit buffer.")
+
+;; Make these survive major-mode changes
+(put 'spacehammer--caller-pid 'permanent-local t)
+(put 'spacehammer--session-id 'permanent-local t)
+(put 'spacehammer--selection-only 'permanent-local t)
+(put 'spacehammer--caller-title 'permanent-local t)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Minor mode
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar spacehammer-edit-with-emacs-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") #'spacehammer-finish-edit-with-emacs)
     (define-key map (kbd "C-c C-k") #'spacehammer-cancel-edit-with-emacs)
+    (define-key map (kbd "C-c C-s") #'spacehammer-sync-edit-with-emacs)
     map))
 
 (define-minor-mode spacehammer-edit-with-emacs-mode
-  "Minor mode enabled on buffers opened by spacehammer/edit-by-emacs."
+  "Minor mode enabled on buffers opened by edit-with-emacs.
+
+\\{spacehammer-edit-with-emacs-mode-map}"
   :init-value nil
-  :lighter " editwithemacs"
+  :lighter " ewe"
   :keymap spacehammer-edit-with-emacs-mode-map
   :group 'spacehammer)
 
 (defun spacehammer--turn-on-edit-with-emacs-mode ()
-  "Turn on `spacehammer-edit-with-emacs-mode' if the buffer derives from that mode."
-  (when (string-match-p "* spacehammer-edit " (buffer-name (current-buffer)))
+  "Turn on `spacehammer-edit-with-emacs-mode' if buffer matches."
+  (when (string-match-p "\\* spacehammer-edit " (buffer-name (current-buffer)))
     (spacehammer-edit-with-emacs-mode t)))
 
 (define-global-minor-mode spacehammer-global-edit-with-emacs-mode
   spacehammer-edit-with-emacs-mode spacehammer--turn-on-edit-with-emacs-mode
   :group 'spacehammer)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Hooks
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar spacehammer-edit-with-emacs-hook nil
   "Hook for when edit-with-emacs buffer gets activated.
@@ -71,68 +126,172 @@ Hook function must accept arguments:
 - `buffer-name' - the name of the edit buffer
 - `pid'         - PID of the app that invoked Edit-with-Emacs")
 
-(defvar spacehammer--caller-pid nil
-  "Buffer local var to store the process id of the app that invoked
-the edit buffer")
+(defvar spacehammer-after-sync-hook nil
+  "Fires after text is synced to the originating app.
+
+Hook function must accept arguments:
+- `buffer-name' - the name of the edit buffer
+- `session-id'  - the session ID")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Helpers
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun spacehammer--find-buffer-by-name-prefix (prefix)
   "Find the first buffer with a name that starts with PREFIX."
-  (let ((buffer-list (buffer-list)))
-    (cl-find-if (lambda (buffer)
-                  (string-prefix-p prefix (buffer-name buffer)))
-                buffer-list)))
+  (cl-find-if (lambda (buffer)
+                (string-prefix-p prefix (buffer-name buffer)))
+              (buffer-list)))
 
-(defun spacehammer-edit-with-emacs (&optional pid title screen)
-  "Edit anything with Emacs.
-The caller is responsible for setting up the arguments.
+(defun spacehammer--escape-lua-string (s)
+  "Escape S for embedding in a Lua string literal (double-quoted)."
+  (replace-regexp-in-string
+   "\n" "\\\\n"
+   (replace-regexp-in-string
+    "\r" "\\\\r"
+    (replace-regexp-in-string
+     "\"" "\\\\\""
+     (replace-regexp-in-string "\\\\" "\\\\\\\\" s)))))
+
+(defun spacehammer--buffer-text ()
+  "Return the text content of the current buffer as a string."
+  (buffer-substring-no-properties (point-min) (point-max)))
+
+(defun spacehammer--key-for (cmd)
+  "Return a human-readable key string for CMD in `spacehammer-edit-with-emacs-mode-map'."
+  (let ((key (where-is-internal cmd spacehammer-edit-with-emacs-mode-map t)))
+    (if key (key-description key) "???")))
+
+(defun spacehammer--set-header-line ()
+  "Set `header-line-format' showing available keybindings for the edit session."
+  (setq header-line-format
+        (list
+         (propertize (format " %s " (or spacehammer--caller-title "Edit"))
+                     'face '(:weight bold :inherit font-lock-function-name-face))
+         (when spacehammer--selection-only
+           (propertize " [selection] " 'face '(:inherit warning)))
+         (propertize " │ " 'face 'shadow)
+         (propertize (spacehammer--key-for #'spacehammer-finish-edit-with-emacs)
+                     'face '(:weight bold :inherit success))
+         (propertize " submit " 'face 'shadow)
+         (propertize "│ " 'face 'shadow)
+         (propertize (spacehammer--key-for #'spacehammer-sync-edit-with-emacs)
+                     'face '(:weight bold :inherit font-lock-constant-face))
+         (propertize " sync " 'face 'shadow)
+         (propertize "│ " 'face 'shadow)
+         (propertize (spacehammer--key-for #'spacehammer-cancel-edit-with-emacs)
+                     'face '(:weight bold :inherit error))
+         (propertize " cancel" 'face 'shadow))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Core: edit-with-emacs (v2 - session based)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun spacehammer-edit-with-emacs (&optional pid title screen session-id selection-only)
+  "Edit text from another app with Emacs.
+
 PID - process ID of the caller app.
-TITLE - title of the window.
-SCREEN - the display from which the call initiates, see:
-www.hammerspoon.org/docs/hs.screen.html."
-  (let* ((buf-name (concat "* spacehammer-edit " title " *"))
-         ;; hook functions later could modify the buffer name, you can't expect to always
-         ;; find the buffer originating from the same app using its full-name, but prefix
-         ;; search would work
-         (buffer (or (spacehammer--find-buffer-by-name-prefix buf-name)
-                     (get-buffer-create buf-name ))))
+TITLE - title of the app window.
+SCREEN - display ID from which the call initiates.
+SESSION-ID - unique session identifier from Hammerspoon.
+SELECTION-ONLY - non-nil if editing only the selected text."
+  (let* ((buf-name (format "* spacehammer-edit %s [%s] *"
+                           (or title "unknown")
+                           (or session-id "legacy")))
+         (buffer (or (spacehammer--find-buffer-by-name-prefix
+                      (format "* spacehammer-edit %s [%s]" (or title "") (or session-id "")))
+                     (get-buffer-create buf-name))))
     (unless (bound-and-true-p spacehammer-global-edit-with-emacs-mode)
       (spacehammer-global-edit-with-emacs-mode +1))
     (with-current-buffer buffer
-      (put 'spacehammer--caller-pid 'permanent-local t)
+      (erase-buffer)
       (setq-local spacehammer--caller-pid pid)
+      (setq-local spacehammer--caller-title title)
+      (setq-local spacehammer--session-id session-id)
+      (setq-local spacehammer--selection-only selection-only)
       (clipboard-yank)
       (deactivate-mark)
+      (goto-char (point-min))
       (spacehammer-edit-with-emacs-mode +1))
     (pop-to-buffer buffer)
-    (run-hook-with-args 'spacehammer-edit-with-emacs-hook buf-name pid title)))
+    (run-hook-with-args 'spacehammer-edit-with-emacs-hook buf-name pid title)
+    ;; Set header-line after hooks - major mode changes (e.g. markdown-mode)
+    ;; in hook functions would otherwise reset it
+    (spacehammer--set-header-line)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Sync - push text without ending session
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun spacehammer-sync-edit-with-emacs ()
+  "Push current buffer text to the originating app without ending the session.
+Bound to C-c C-s in edit-with-emacs buffers."
+  (interactive)
+  (let ((session-id spacehammer--session-id)
+        (text (spacehammer--buffer-text)))
+    (unless session-id
+      (user-error "No session ID - cannot sync (legacy session?)"))
+    (let ((escaped (spacehammer--escape-lua-string text)))
+      (spacehammer--hs-cmd
+       (format "require(\"emacs\").syncText(\"%s\", \"%s\")"
+               session-id escaped)
+       t))
+    (message "Synced to %s" (or spacehammer--caller-pid "app"))
+    (run-hook-with-args 'spacehammer-after-sync-hook
+                        (buffer-name) session-id)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Finish - push text and end session
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun spacehammer-finish-edit-with-emacs ()
-  "Invoke this command when done editing."
+  "Finish editing: send text to originating app and close the buffer."
   (interactive)
-  (unless (executable-find "hs")
-    (user-error "Hammerspoon IPC command line (hs) not found."))
-  (when (boundp 'spacehammer--caller-pid)
-    (let ((pid (buffer-local-value 'spacehammer--caller-pid (current-buffer))))
-      (run-hook-with-args
-       'spacehammer-before-finish-edit-with-emacs-hook
-       (buffer-name (current-buffer)) pid)
-      (clipboard-kill-ring-save (point-min) (point-max))
-      (if (one-window-p)
-          (kill-buffer)
-        (kill-buffer-and-window))
-      (call-process
-       (executable-find "hs") nil 0 nil "-c"
-       (concat "require(\"emacs\").switchToAppAndPasteFromClipboard (\"" pid "\")")))))
+  (let ((pid spacehammer--caller-pid)
+        (session-id spacehammer--session-id)
+        (text (spacehammer--buffer-text)))
+    (run-hook-with-args
+     'spacehammer-before-finish-edit-with-emacs-hook
+     (buffer-name (current-buffer)) pid)
+    (if session-id
+        ;; v2: session-based
+        (let ((escaped (spacehammer--escape-lua-string text)))
+          (if (one-window-p)
+              (kill-buffer)
+            (kill-buffer-and-window))
+          (spacehammer--hs-cmd
+           (format "require(\"emacs\").finishSession(\"%s\", \"%s\")"
+                   session-id escaped)
+           t))
+      ;; Legacy fallback (no session-id)
+      (progn
+        (clipboard-kill-ring-save (point-min) (point-max))
+        (if (one-window-p)
+            (kill-buffer)
+          (kill-buffer-and-window))
+        (spacehammer--hs-cmd
+         (format "require(\"emacs\").switchToAppAndPasteFromClipboard(\"%s\")" pid)
+         t)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Cancel - abandon edits
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun spacehammer-cancel-edit-with-emacs ()
-  "Invoke it to cancel previous editing session."
+  "Cancel editing: switch back to originating app without modifying text."
   (interactive)
-  (when (boundp 'spacehammer--caller-pid)
-    (let ((pid (buffer-local-value 'spacehammer--caller-pid (current-buffer))))
-      (run-hook-with-args
-       'spacehammer-before-cancel-edit-with-emacs-hook
-       (buffer-name (current-buffer)) pid)
-      (kill-buffer-and-window)
+  (let ((pid spacehammer--caller-pid)
+        (session-id spacehammer--session-id))
+    (run-hook-with-args
+     'spacehammer-before-cancel-edit-with-emacs-hook
+     (buffer-name (current-buffer)) pid)
+    (if (one-window-p)
+        (kill-buffer)
+      (kill-buffer-and-window))
+    (if session-id
+        (spacehammer--hs-cmd
+         (format "require(\"emacs\").cancelSession(\"%s\")" session-id)
+         t)
       (spacehammer-switch-to-app pid))))
 
 ;;;; System-wide org capture


### PR DESCRIPTION
Some nice improvements:

- multiple edit buffers - each app can have its own edit buffer now

- sync - updating the text without closing the buffer

- selection-aware editing. pre-selected text portion after "sync" gets replaced without affecting the rest of the text