### PR TITLE
fix(ewe): skip AX write-back for Slack, add clipboard-write-back helper

### DIFF
--- a/emacs.fnl
+++ b/emacs.fnl
@@ -10,23 +10,22 @@
 
 (fn gen-session-id []
   (set session-counter (+ session-counter 1))
-  (.. "ewe-" session-counter "-" (math.floor (* (hs.timer.absoluteTime) 0.000001))))
+  (.. "ewe-" session-counter "-"
+      (math.floor (* (hs.timer.absoluteTime) 0.000001))))
 
 (fn get-focused-text-element []
   "Get the currently focused UI element via Accessibility API.
    Returns the element if it's a text-editable field with settable AXValue,
    nil otherwise (triggers clipboard fallback)."
   (let [sys (ax.systemWideElement)
-        el  (sys:attributeValue :AXFocusedUIElement)]
+        el (sys:attributeValue :AXFocusedUIElement)]
     (when el
-      (let [role     (el:attributeValue :AXRole)
+      (let [role (el:attributeValue :AXRole)
             settable (el:isAttributeSettable :AXValue)]
         ;; only return elements that are text-like AND have a settable value
         (when (and settable
-                   (or (= role :AXTextArea)
-                       (= role :AXTextField)
-                       (= role :AXComboBox)
-                       (= role :AXTextView)))
+                   (or (= role :AXTextArea) (= role :AXTextField)
+                       (= role :AXComboBox) (= role :AXTextView)))
           el)))))
 
 (fn ax-set-value [el text]
@@ -42,7 +41,7 @@
   (let [app (hs.application.applicationForPID (tonumber pid))]
     (when app
       (let [ax-app (ax.applicationElement app)
-            el     (ax-app:attributeValue :AXFocusedUIElement)]
+            el (ax-app:attributeValue :AXFocusedUIElement)]
         (when (and el (el:isAttributeSettable :AXValue))
           el)))))
 
@@ -53,6 +52,14 @@
       (: :gsub "\"" "\\\\\"")
       (: :gsub "\n" "\\\\n")
       (: :gsub "\r" "\\\\r")))
+
+;; Apps where AX write-back produces garbled text (e.g., Electron apps
+;; that insert extra blank lines). AX reads still used for prefix/suffix.
+(var ax-write-blocklist {:com.tinyspeck.slackmacgap true})
+
+(fn ax-write-blocked? [app]
+  "True when app is known to mangle text set via AXValue."
+  (and app (. ax-write-blocklist (app:bundleID))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Emacsclient helpers
@@ -69,15 +76,12 @@
             (: :path)
             (: :gsub "Emacs.app" "bin/emacsclient")))))
 
-(fn run-emacs-fn
-  [elisp-fn args]
+(fn run-emacs-fn [elisp-fn args]
   "Executes given elisp function in emacsclient. If args table present, passes
    them into the function."
   (let [args-lst (when args (.. " '" (table.concat args " '")))
-        run-str  (.. (emacsclient-exe)
-                     " -e \"(funcall '" elisp-fn
-                     (if args-lst args-lst " &")
-                     ")\" &")]
+        run-str (.. (emacsclient-exe) " -e \"(funcall '" elisp-fn
+                    (if args-lst args-lst " &") ")\" &")]
     (io.popen run-str)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -86,16 +90,14 @@
 
 (fn capture [is-note]
   "Activates org-capture"
-  (let [key         (if is-note "\"z\"" "")
+  (let [key (if is-note "\"z\"" "")
         current-app (hs.window.focusedWindow)
-        pid         (.. "\"" (current-app:pid) "\" ")
-        title       (.. "\"" (current-app:title) "\" ")
-        run-str     (..
-                     (emacsclient-exe)
-                     " -c -F '(quote (name . \"capture\"))'"
-                     " -e '(spacehammer-activate-capture-frame "
-                     pid title key " )' &")
-        timer       (hs.timer.delayed.new .1 (fn [] (io.popen run-str)))]
+        pid (.. "\"" (current-app:pid) "\" ")
+        title (.. "\"" (current-app:title) "\" ")
+        run-str (.. (emacsclient-exe) " -c -F '(quote (name . \"capture\"))'"
+                    " -e '(spacehammer-activate-capture-frame " pid title key
+                    " )' &")
+        timer (hs.timer.delayed.new .1 (fn [] (io.popen run-str)))]
     (timer:start)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -117,44 +119,45 @@
 
 (fn open-emacs-for-session [session-id session had-selection]
   "Open emacsclient for an edit session. Called after clipboard is ready."
-  (let [run-str (..
-                 (emacsclient-exe)
-                 " -e '(spacehammer-edit-with-emacs "
-                 "\"" session.pid "\" "
-                 "\"" (escape-elisp-string session.title) "\" "
-                 "\"" session.screen "\" "
-                 "\"" session-id "\" "
-                 (if had-selection "t" "nil")
-                 " )' &")]
+  (let [run-str (.. (emacsclient-exe) " -e '(spacehammer-edit-with-emacs " "\""
+                    session.pid "\" " "\"" (escape-elisp-string session.title)
+                    "\" " "\"" session.screen "\" " "\"" session-id "\" "
+                    (if had-selection "t" "nil") " )' &")]
     (io.popen run-str)
     (hs.application.open :Emacs)))
 
-(fn build-session [session-id pid title screen-id ax-el had-selection]
+(fn build-session [session-id
+                   pid
+                   title
+                   screen-id
+                   ax-el
+                   had-selection
+                   ax-blocked]
   "Read clipboard and AX state, create session entry, open Emacs."
   (log.i (.. "build-session: " session-id " sel=" (tostring had-selection)
              " ax=" (tostring (not= nil ax-el))))
   (let [selected-text (hs.pasteboard.getContents)
-        full-text     (when ax-el (ax-el:attributeValue :AXValue))
+        full-text (when ax-el (ax-el:attributeValue :AXValue))
         ;; For selection mode with AX: find prefix/suffix anchors
-        prefix        (when (and had-selection full-text selected-text)
-                        (let [pos (string.find full-text selected-text 1 true)]
-                          (when pos
-                            (full-text:sub 1 (- pos 1)))))
-        suffix        (when (and had-selection full-text selected-text prefix)
-                        (let [end-pos (+ (length prefix) (length selected-text))]
-                          (full-text:sub (+ end-pos 1))))
-        mode          (if ax-el :ax :clipboard)
-        session       {:pid           pid
-                       :title         title
-                       :screen        screen-id
-                       :ax-element    ax-el
-                       :mode          mode
-                       :has-selection had-selection
-                       :prefix        prefix
-                       :suffix        suffix
-                       :original      selected-text}]
-    (log.i (.. "session " session-id ": mode=" mode
-               " text-len=" (tostring (and selected-text (length selected-text)))))
+        prefix (when (and had-selection full-text selected-text)
+                 (let [pos (string.find full-text selected-text 1 true)]
+                   (when pos
+                     (full-text:sub 1 (- pos 1)))))
+        suffix (when (and had-selection full-text selected-text prefix)
+                 (let [end-pos (+ (length prefix) (length selected-text))]
+                   (full-text:sub (+ end-pos 1))))
+        mode (if (and ax-el (not ax-blocked)) :ax :clipboard)
+        session {:pid pid
+                 :title title
+                 :screen screen-id
+                 :ax-element ax-el
+                 :mode mode
+                 :has-selection had-selection
+                 :prefix prefix
+                 :suffix suffix
+                 :original selected-text}]
+    (log.i (.. "session " session-id ": mode=" mode " text-len="
+               (tostring (and selected-text (length selected-text)))))
     (tset sessions session-id session)
     (open-emacs-for-session session-id session had-selection)))
 
@@ -164,32 +167,48 @@
    Async: waits for clipboard to actually change before proceeding."
   (let [current-win (hs.window.focusedWindow)
         current-app (current-win:application)
-        pid         (current-app:pid)
-        title       (current-app:title)
-        screen-id   (tostring (: (hs.screen.mainScreen) :id))
-        session-id  (gen-session-id)
-        ax-el       (get-focused-text-element)
-        prev-count  (hs.pasteboard.changeCount)]
+        pid (current-app:pid)
+        title (current-app:title)
+        screen-id (tostring (: (hs.screen.mainScreen) :id))
+        session-id (gen-session-id)
+        ax-el (get-focused-text-element)
+        ax-blocked (ax-write-blocked? current-app)
+        prev-count (hs.pasteboard.changeCount)]
     ;; Send Cmd+C and wait for clipboard to change
     (hs.eventtap.keyStroke [:cmd] :c)
     (wait-for-clipboard-change prev-count
-      (fn [got-selection]
-        (if got-selection
-            ;; User had text selected - Cmd+C worked
-            (build-session session-id pid title screen-id ax-el true)
-            ;; Nothing was selected - grab everything with Cmd+A, Cmd+C
-            (let [prev2 (hs.pasteboard.changeCount)]
-              (hs.eventtap.keyStroke [:cmd] :a)
-              (hs.eventtap.keyStroke [:cmd] :c)
-              (wait-for-clipboard-change prev2
-                (fn [got-all]
-                  (if got-all
-                      (build-session session-id pid title screen-id ax-el false)
-                      ;; Last resort: maybe AX has the text directly
-                      (let [ax-text (when ax-el (ax-el:attributeValue :AXValue))]
-                        (when ax-text
-                          (hs.pasteboard.setContents ax-text))
-                        (build-session session-id pid title screen-id ax-el false)))))))))))
+                               (fn [got-selection]
+                                 (if got-selection
+                                     ;; User had text selected - Cmd+C worked
+                                     (build-session session-id pid title
+                                                    screen-id ax-el true
+                                                    ax-blocked)
+                                     ;; Nothing was selected - grab everything with Cmd+A, Cmd+C
+                                     (let [prev2 (hs.pasteboard.changeCount)]
+                                       (hs.eventtap.keyStroke [:cmd] :a)
+                                       (hs.eventtap.keyStroke [:cmd] :c)
+                                       (wait-for-clipboard-change prev2
+                                                                  (fn [got-all]
+                                                                    (if got-all
+                                                                        (build-session session-id
+                                                                                       pid
+                                                                                       title
+                                                                                       screen-id
+                                                                                       ax-el
+                                                                                       false
+                                                                                       ax-blocked)
+                                                                        ;; Last resort: maybe AX has the text directly
+                                                                        (let [ax-text (when ax-el
+                                                                                        (ax-el:attributeValue :AXValue))]
+                                                                          (when ax-text
+                                                                            (hs.pasteboard.setContents ax-text))
+                                                                          (build-session session-id
+                                                                                         pid
+                                                                                         title
+                                                                                         screen-id
+                                                                                         ax-el
+                                                                                         false
+                                                                                         ax-blocked)))))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; IPC functions - callable from Emacs via `hs -c`
@@ -204,10 +223,10 @@
       (when app
         (app:activate)
         (hs.timer.doAfter 0.05
-          (fn []
-            (hs.eventtap.keyStroke [:cmd] :v)
-            (when then-fn
-              (hs.timer.doAfter 0.05 then-fn)))))))
+                          (fn []
+                            (hs.eventtap.keyStroke [:cmd] :v)
+                            (when then-fn
+                              (hs.timer.doAfter 0.05 then-fn)))))))
   "ok")
 
 (fn session-write-ax [session text]
@@ -216,8 +235,8 @@
    element if the stored one went stale. Returns true on success."
   (let [;; try stored element first, re-acquire if stale
         el (or session.ax-element (ax-get-app-element session.pid))]
-    (log.i (.. "write-ax: el=" (tostring (not= nil el))
-               " sel=" (tostring session.has-selection)))
+    (log.i (.. "write-ax: el=" (tostring (not= nil el)) " sel="
+               (tostring session.has-selection)))
     (when el
       ;; update stored ref in case we re-acquired
       (tset session :ax-element el)
@@ -230,10 +249,42 @@
         ;; Delay is needed: apps reset AXSelectedTextRange when AXValue changes.
         (when (and result sel?)
           (hs.timer.doAfter 0.1
-            (fn []
-              (el:setAttributeValue :AXSelectedTextRange
-                {:location (length session.prefix) :length (length text)}))))
+                            (fn []
+                              (el:setAttributeValue :AXSelectedTextRange
+                                                    {:location (length session.prefix)
+                                                     :length (length text)}))))
         result))))
+
+(fn clipboard-write-back [session text opts]
+  "Write text back via clipboard paste. When prefix/suffix anchors exist,
+   reconstructs the full field content and selects all before pasting."
+  (let [has-anchors (and session.has-selection session.prefix session.suffix)
+        full-text (if has-anchors
+                      (.. session.prefix text session.suffix)
+                      text)
+        select-all? (or (not session.has-selection) has-anchors)
+        then-fn (. (or opts {}) :then-fn)]
+    (hs.pasteboard.setContents full-text)
+    (let [app (hs.application.applicationForPID (tonumber session.pid))]
+      (when app
+        (app:activate)
+        (hs.timer.doAfter 0.05
+                          (fn []
+                            (if select-all?
+                                (do
+                                  (hs.eventtap.keyStroke [:cmd] :a)
+                                  (hs.timer.doAfter 0.02
+                                                    (fn []
+                                                      (hs.eventtap.keyStroke [:cmd]
+                                                                             :v)
+                                                      (when then-fn
+                                                        (hs.timer.doAfter 0.1
+                                                                          then-fn)))))
+                                (do
+                                  (hs.eventtap.keyStroke [:cmd] :v)
+                                  (when then-fn
+                                    (hs.timer.doAfter 0.05 then-fn)))))))))
+  "ok")
 
 (fn sync-text [session-id text]
   "Push text from Emacs back to the originating app's text field without
@@ -250,27 +301,10 @@
             (hs.pasteboard.setContents text)
             "ok")
           ;; clipboard fallback
-          (if session.has-selection
-              ;; paste over preserved visual selection, then return to Emacs
-              (do
-                (paste-via-clipboard text session.pid
-                  {:then-fn (fn [] (hs.application.open :Emacs))})
-                "ok")
-              ;; no selection: select all, paste, return to Emacs
-              (do
-                (hs.pasteboard.setContents text)
-                (let [app (hs.application.applicationForPID (tonumber session.pid))]
-                  (when app
-                    (app:activate)
-                    (hs.timer.doAfter 0.05
-                      (fn []
-                        (hs.eventtap.keyStroke [:cmd] :a)
-                        (hs.timer.doAfter 0.02
-                          (fn []
-                            (hs.eventtap.keyStroke [:cmd] :v)
-                            (hs.timer.doAfter 0.1
-                              (fn [] (hs.application.open :Emacs)))))))))
-                "ok"))))))
+          (do
+            (clipboard-write-back session text
+                                  {:then-fn (fn [] (hs.application.open :Emacs))})
+            "ok")))))
 
 (fn finish-session [session-id text]
   "Finish editing: write final text to originating app and end session.
@@ -288,7 +322,7 @@
             (let [app (hs.application.applicationForPID (tonumber session.pid))]
               (when app (app:activate))))
           ;; clipboard fallback
-          (paste-via-clipboard text session.pid {}))
+          (clipboard-write-back session text))
       ;; clean up session
       (tset sessions session-id nil)
       "ok")))
@@ -307,11 +341,9 @@
   "Return session metadata as a string for Emacs. Callable from Emacs."
   (let [session (. sessions session-id)]
     (if session
-        (.. "{:mode \"" session.mode "\""
-            " :pid \"" (tostring session.pid) "\""
-            " :title \"" (escape-elisp-string session.title) "\""
-            " :has-selection " (if session.has-selection "true" "false")
-            "}")
+        (.. "{:mode \"" session.mode "\"" " :pid \"" (tostring session.pid)
+            "\"" " :title \"" (escape-elisp-string session.title) "\""
+            " :has-selection " (if session.has-selection "true" "false") "}")
         "nil")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -330,72 +362,61 @@
   (let [app (hs.application.applicationForPID (tonumber pid))]
     (when app
       (app:activate)
-      (hs.timer.doAfter
-       0.001
-       (fn [] (app:selectMenuItem [:Edit :Paste]))))))
+      (hs.timer.doAfter 0.001 (fn [] (app:selectMenuItem [:Edit :Paste]))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Emacs window management
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(fn full-screen
-  []
+(fn full-screen []
   "Switches to current instance of GUI Emacs and makes its frame fullscreen"
   (hs.application.launchOrFocus :Emacs)
-  (run-emacs-fn
-   (..
-    "(lambda ())"
-    "(spacemacs/toggle-fullscreen-frame-on)"
-    "(spacehammer/fix-frame)")))
+  (run-emacs-fn (.. "(lambda ())" "(spacemacs/toggle-fullscreen-frame-on)"
+                    "(spacehammer/fix-frame)")))
 
-(fn vertical-split-with-emacs
-  []
+(fn vertical-split-with-emacs []
   "Creates vertical split with Emacs window sitting next to the current app"
-  (let [windows    (require :windows)
-        cur-app    (-?> (hs.window.focusedWindow) (: :application) (: :name))
-        rect-left  [0  0 .5  1]
-        rect-right [.5 0 .5  1]
-        elisp      (.. "(lambda ()"
-                       " (spacemacs/toggle-fullscreen-frame-off) "
-                       " (spacemacs/maximize-horizontally) "
-                       " (spacemacs/maximize-vertically))")]
+  (let [windows (require :windows)
+        cur-app (-?> (hs.window.focusedWindow) (: :application) (: :name))
+        rect-left [0 0 .5 1]
+        rect-right [.5 0 .5 1]
+        elisp (.. "(lambda ()" " (spacemacs/toggle-fullscreen-frame-off) "
+                  " (spacemacs/maximize-horizontally) "
+                  " (spacemacs/maximize-vertically))")]
     (run-emacs-fn elisp)
-    (hs.timer.doAfter
-     .2
-     (fn []
-       (if (= cur-app :Emacs)
-           (do
-             (windows.rect rect-left)
-             (windows.jump-to-last-window)
-             (windows.rect rect-right))
-           (do
-             (windows.rect rect-right)
-             (hs.application.launchOrFocus :Emacs)
-             (windows.rect rect-left)))))))
+    (hs.timer.doAfter .2
+                      (fn []
+                        (if (= cur-app :Emacs)
+                            (do
+                              (windows.rect rect-left)
+                              (windows.jump-to-last-window)
+                              (windows.rect rect-right))
+                            (do
+                              (windows.rect rect-right)
+                              (hs.application.launchOrFocus :Emacs)
+                              (windows.rect rect-left)))))))
 
-(fn maximize
-  []
+(fn maximize []
   "Maximizes Emacs GUI window after a short delay."
-  (hs.timer.doAfter
-   1.5
-   (fn []
-     (let [app     (hs.application.find :Emacs)
-           windows (require :windows)]
-       (when app
-         (app:activate)
-         (windows.maximize-window-frame))))))
+  (hs.timer.doAfter 1.5
+                    (fn []
+                      (let [app (hs.application.find :Emacs)
+                            windows (require :windows)]
+                        (when app
+                          (app:activate)
+                          (windows.maximize-window-frame))))))
 
-{:capture                          capture
- :edit-with-emacs                  edit-with-emacs
- :full-screen                      full-screen
- :maximize                         maximize
- :note                             (fn [] (capture true))
- :switchToApp                      switch-to-app
+{:capture capture
+ :edit-with-emacs edit-with-emacs
+ :full-screen full-screen
+ :maximize maximize
+ :note (fn [] (capture true))
+ :switchToApp switch-to-app
  :switchToAppAndPasteFromClipboard switch-to-app-and-paste-from-clipboard
- :vertical-split-with-emacs        vertical-split-with-emacs
- :run-emacs-fn                     run-emacs-fn
+ :vertical-split-with-emacs vertical-split-with-emacs
+ :run-emacs-fn run-emacs-fn
  ;; New session-based IPC
- :syncText                         sync-text
- :finishSession                    finish-session
- :cancelSession                    cancel-session
- :getSessionInfo                   get-session-info}
+ :syncText sync-text
+ :finishSession finish-session
+ :cancelSession cancel-session
+ :getSessionInfo get-session-info}


### PR DESCRIPTION
Slack's Electron-based text areas mangle newlines into paragraph breaks when text is set via AXValue, producing blank lines between every line.

- Add ax-write-blocklist to force clipboard mode for known-bad apps (AX reads still used for prefix/suffix computation)
- Add clipboard-write-back that reconstructs full text from prefix/edit/suffix and does Cmd+A before paste when replacing the entire field
- Simplify sync-text and finish-session clipboard fallback paths